### PR TITLE
Connect new strategy page to API

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -1,0 +1,6 @@
+# 準備
+
+1. Azure Functions Core Tools のインストール
+2. `cd Stratrack.Api` を実行する
+3. `func start` を実行する
+4. http://localhost:7071/api/swagger/ui にアクセスする

--- a/api/Stratrack.Api/Functions/StrategyFunctions.cs
+++ b/api/Stratrack.Api/Functions/StrategyFunctions.cs
@@ -20,7 +20,7 @@ public class StrategyFunctions(ICommandBus commandBus, IQueryProcessor queryProc
     [OpenApiSecurity("function_key", SecuritySchemeType.ApiKey, In = OpenApiSecurityLocationType.Header, Name = "x-functions-key")]
     [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "application/json", bodyType: typeof(List<StrategySummary>))]
     [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.Unauthorized, Description = "Not authorized")]
-    public async Task<HttpResponseData> GetStrategies([HttpTrigger(AuthorizationLevel.Function, "get", Route = "api/strategies")] HttpRequestData req, CancellationToken token)
+    public async Task<HttpResponseData> GetStrategies([HttpTrigger(AuthorizationLevel.Function, "get", Route = "strategies")] HttpRequestData req, CancellationToken token)
     {
         var results = await queryProcessor.ProcessAsync(new StrategyReadModelSearchQuery(), token).ConfigureAwait(false);
         var response = req.CreateResponse(HttpStatusCode.OK);

--- a/frontend/src/api/strategies.ts
+++ b/frontend/src/api/strategies.ts
@@ -1,0 +1,59 @@
+export type NewStrategyRequest = {
+  name: string;
+  description?: string;
+  tags?: string[];
+  template: Record<string, unknown>;
+  generatedCode?: string;
+};
+
+export type StrategySummary = {
+  id: string;
+  name: string;
+  latestVersion: number;
+  latestVersionId: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type StrategyDetail = {
+  id: string;
+  latestVersion?: number;
+  latestVersionId?: string;
+  name: string;
+  description?: string;
+  tags: string[];
+  template: Record<string, unknown>;
+  generatedCode?: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? '';
+
+export async function listStrategies(): Promise<StrategySummary[]> {
+  const res = await fetch(`${API_BASE_URL}/api/strategies`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch strategies: ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function getStrategy(id: string): Promise<StrategyDetail> {
+  const res = await fetch(`${API_BASE_URL}/api/strategies/${id}`);
+  if (!res.ok) {
+    throw new Error(`Failed to fetch strategy: ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function createStrategy(data: NewStrategyRequest) {
+  const res = await fetch(`${API_BASE_URL}/api/strategies`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(data),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to create strategy: ${res.status}`);
+  }
+  return res.json();
+}

--- a/frontend/src/routes/strategies/index.tsx
+++ b/frontend/src/routes/strategies/index.tsx
@@ -1,8 +1,20 @@
 import { Link, useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
 import Button from "../../components/Button";
+import {
+  listStrategies,
+  StrategySummary,
+} from "../../api/strategies";
 
 const Strategies = () => {
   const navigate = useNavigate();
+  const [strategies, setStrategies] = useState<StrategySummary[]>([]);
+
+  useEffect(() => {
+    listStrategies()
+      .then(setStrategies)
+      .catch((err) => console.error(err));
+  }, []);
   return (
     <div className="p-6 space-y-6">
       <header className="flex justify-between items-center">
@@ -13,19 +25,21 @@ const Strategies = () => {
       <section>
         <h3 className="text-lg font-semibold mb-2">戦略一覧</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {/* Sample Card */}
-          {[1, 2, 3].map((i) => (
-            <div key={i} className="rounded-xl border p-4 shadow">
-              <h4 className="font-bold">戦略 {i}</h4>
-              <p className="text-sm text-gray-600">説明文をここに表示</p>
+          {strategies.map((s) => (
+            <div key={s.id} className="rounded-xl border p-4 shadow">
+              <h4 className="font-bold">{s.name}</h4>
+              <p className="text-sm text-gray-600">最新版: {s.latestVersion}</p>
               <Link
-                to={`/strategies/${i}`}
+                to={`/strategies/${s.id}`}
                 className="mt-2 bg-primary text-primary-content py-1 px-3 rounded"
               >
                 詳細
               </Link>
             </div>
           ))}
+          {strategies.length === 0 && (
+            <p className="col-span-full text-center text-gray-500">戦略がありません</p>
+          )}
         </div>
       </section>
     </div>

--- a/frontend/src/routes/strategies/new.tsx
+++ b/frontend/src/routes/strategies/new.tsx
@@ -1,4 +1,20 @@
+import { FormEvent, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { createStrategy } from "../../api/strategies";
+
 const NewStrategy = () => {
+  const navigate = useNavigate();
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    await createStrategy({
+      name,
+      description,
+      template: {},
+    });
+    navigate("/strategies");
+  };
   return (
     <div className="p-6 space-y-6">
       <header className="flex justify-between items-center">
@@ -7,13 +23,16 @@ const NewStrategy = () => {
 
       <section>
         <h3 className="text-lg font-semibold mb-2">戦略の詳細を入力してください</h3>
-        <form className="space-y-4">
+        <form className="space-y-4" onSubmit={handleSubmit}>
           <div>
             <label className="block text-sm font-medium text-gray-700">戦略名</label>
             <input
               type="text"
               className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-primary focus:border-primary"
               placeholder="戦略名を入力"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              required
             />
           </div>
           <div>
@@ -21,6 +40,8 @@ const NewStrategy = () => {
             <textarea
               className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-primary focus:border-primary"
               placeholder="戦略の説明を入力"
+              value={description}
+              onChange={(e) => setDescription(e.target.value)}
             ></textarea>
           </div>
           <button type="submit" className="mt-4 bg-primary text-primary-content py-2 px-4 rounded">

--- a/frontend/src/routes/strategies/show.tsx
+++ b/frontend/src/routes/strategies/show.tsx
@@ -1,32 +1,32 @@
+import { useEffect, useState } from "react";
+import { useParams } from "react-router-dom";
+import { getStrategy, StrategyDetail } from "../../api/strategies";
+
 const StrategyDetails = () => {
+  const { strategyId } = useParams<{ strategyId: string }>();
+  const [strategy, setStrategy] = useState<StrategyDetail | null>(null);
+
+  useEffect(() => {
+    if (strategyId) {
+      getStrategy(strategyId)
+        .then(setStrategy)
+        .catch((err) => console.error(err));
+    }
+  }, [strategyId]);
+
+  if (!strategy) {
+    return <p className="p-6">Loading...</p>;
+  }
+
   return (
     <div className="p-6 space-y-6">
       <header className="flex justify-between items-center">
-        <h2 className="text-2xl font-bold">詳細</h2>
+        <h2 className="text-2xl font-bold">{strategy.name}</h2>
       </header>
 
       <section>
-        <h3 className="text-lg font-semibold mb-2">戦略の詳細を入力してください</h3>
-        <form className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-700">戦略名</label>
-            <input
-              type="text"
-              className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-primary focus:border-primary"
-              placeholder="戦略名を入力"
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700">説明</label>
-            <textarea
-              className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-primary focus:border-primary"
-              placeholder="戦略の説明を入力"
-            ></textarea>
-          </div>
-          <button type="submit" className="mt-4 bg-primary text-primary-content py-2 px-4 rounded">
-            作成
-          </button>
-        </form>
+        <h3 className="text-lg font-semibold mb-2">説明</h3>
+        <p className="whitespace-pre-wrap">{strategy.description ?? "(なし)"}</p>
       </section>
     </div>
   );

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,12 +1,17 @@
 /// <reference types="vitest" />
-import { defineConfig } from 'vite'
-import react from '@vitejs/plugin-react-swc'
-import tailwindcss from '@tailwindcss/vite'
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react-swc";
+import tailwindcss from "@tailwindcss/vite";
 
 // https://vite.dev/config/
 export default defineConfig({
-  plugins: [
-    react(),
-    tailwindcss(),
-  ],
-})
+  plugins: [react(), tailwindcss()],
+  server: {
+    proxy: {
+      "/api": {
+        target: "http://127.0.0.1:7071",
+        changeOrigin: true,
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- add simple API client for strategies
- hook strategy creation page up to API
- list and view strategies from the API

## Testing
- `npm run lint`
- `npx vitest run`


------
https://chatgpt.com/codex/tasks/task_e_6856715bf6448320972f1fc5fad76a95