### PR TITLE
Refactor StrategyEditor to handle empty templates

### DIFF
--- a/frontend/src/features/strategies/StrategyEditor.test.tsx
+++ b/frontend/src/features/strategies/StrategyEditor.test.tsx
@@ -1,0 +1,19 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderToString } from "react-dom/server";
+import StrategyEditor from "./StrategyEditor";
+
+vi.mock("../../components/CodeEditor", () => ({
+  default: () => null,
+}));
+vi.mock("../indicators/IndicatorProvider", () => ({
+  useIndicatorList: () => [],
+}));
+
+describe("StrategyEditor", () => {
+  it("renders with empty template without throwing", () => {
+    expect(() =>
+      renderToString(<StrategyEditor value={{ template: {} }} />)
+    ).not.toThrow();
+  });
+});
+

--- a/frontend/src/features/strategies/StrategyEditor.tsx
+++ b/frontend/src/features/strategies/StrategyEditor.tsx
@@ -1,4 +1,4 @@
-import { Suspense, useMemo } from "react";
+import { useMemo } from "react";
 import CodeEditor from "../../components/CodeEditor";
 import { useLocalValue } from "../../hooks/useLocalValue";
 import StrategyTemplateEditor from "./components/StrategyTemplateEditor";
@@ -6,6 +6,14 @@ import { renderStrategyCode } from "../../codegen/generators/strategyCodeRendere
 import BasicInfo from "./sections/BasicInfo";
 import { useIndicatorList } from "../indicators/IndicatorProvider";
 import { Strategy, StrategyTemplate } from "../../codegen/dsl/strategy";
+import Tab from "../../components/Tab";
+
+const DEFAULT_TEMPLATE: StrategyTemplate = {
+  variables: [],
+  entry: [],
+  exit: [],
+  riskManagement: { type: "percentage", percent: 100 },
+};
 
 export type StrategyEditorProps = {
   value?: Partial<Strategy>;
@@ -15,37 +23,52 @@ export type StrategyEditorProps = {
 function StrategyEditor({ value, onChange }: StrategyEditorProps) {
   const indicators = useIndicatorList();
   const [localValue, setLocalValue] = useLocalValue(
-    {
-      template: {
-        variables: [],
-        entry: [],
-        exit: [],
-        riskManagement: { type: "percentage", percent: 100 },
-      } as StrategyTemplate,
-    } as Partial<Strategy>,
+    { template: DEFAULT_TEMPLATE } as Partial<Strategy>,
     value,
     onChange
   );
+
+  const template = useMemo(
+    () => ({ ...DEFAULT_TEMPLATE, ...localValue.template }),
+    [localValue.template]
+  );
+
   return (
     <div className="grid space-y-4">
       <BasicInfo value={localValue} onChange={setLocalValue} />
       <StrategyTemplateEditor value={localValue} onChange={setLocalValue} />
-      <Suspense fallback={<div className="text-red-500">エラーが発生しました。</div>}>
-        <CodeEditor
-          language="python"
-          value={useMemo(
-            () => renderStrategyCode("python", localValue.template as StrategyTemplate, indicators),
-            [localValue, indicators]
-          )}
-        />
-        <CodeEditor
-          language="mql4"
-          value={useMemo(
-            () => renderStrategyCode("mql4", localValue.template as StrategyTemplate, indicators),
-            [localValue, indicators]
-          )}
-        />
-      </Suspense>
+      <Tab
+        tabs={[
+          {
+            id: "python",
+            label: "Python",
+            content: (
+              <CodeEditor
+                language="python"
+                value={useMemo(
+                  () => renderStrategyCode("python", template, indicators),
+                  [template, indicators]
+                )}
+                readOnly
+              />
+            ),
+          },
+          {
+            id: "mql4",
+            label: "MQL4",
+            content: (
+              <CodeEditor
+                language="mql4"
+                value={useMemo(
+                  () => renderStrategyCode("mql4", template, indicators),
+                  [template, indicators]
+                )}
+                readOnly
+              />
+            ),
+          },
+        ]}
+      />
     </div>
   );
 }

--- a/frontend/src/routes/strategies/new.tsx
+++ b/frontend/src/routes/strategies/new.tsx
@@ -1,20 +1,36 @@
 import { FormEvent, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { createStrategy } from "../../api/strategies";
+import StrategyEditor from "../../features/strategies/StrategyEditor";
+import { Strategy, StrategyTemplate } from "../../codegen/dsl/strategy";
+import { renderStrategyCode } from "../../codegen/generators/strategyCodeRenderer";
+import { useIndicatorList } from "../../features/indicators/IndicatorProvider";
 
 const NewStrategy = () => {
   const navigate = useNavigate();
-  const [name, setName] = useState("");
-  const [description, setDescription] = useState("");
+  const indicators = useIndicatorList();
+  const [strategy, setStrategy] = useState<Partial<Strategy>>({});
+
   const handleSubmit = async (e: FormEvent) => {
     e.preventDefault();
+    if (!strategy.name || !strategy.template) {
+      return;
+    }
+    const generatedCode = renderStrategyCode(
+      "python",
+      strategy.template as StrategyTemplate,
+      indicators
+    );
     await createStrategy({
-      name,
-      description,
-      template: {},
+      name: strategy.name,
+      description: strategy.description,
+      tags: strategy.tags,
+      template: strategy.template as Record<string, unknown>,
+      generatedCode,
     });
     navigate("/strategies");
   };
+
   return (
     <div className="p-6 space-y-6">
       <header className="flex justify-between items-center">
@@ -24,27 +40,11 @@ const NewStrategy = () => {
       <section>
         <h3 className="text-lg font-semibold mb-2">戦略の詳細を入力してください</h3>
         <form className="space-y-4" onSubmit={handleSubmit}>
-          <div>
-            <label className="block text-sm font-medium text-gray-700">戦略名</label>
-            <input
-              type="text"
-              className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-primary focus:border-primary"
-              placeholder="戦略名を入力"
-              value={name}
-              onChange={(e) => setName(e.target.value)}
-              required
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700">説明</label>
-            <textarea
-              className="mt-1 block w-full border-gray-300 rounded-md shadow-sm focus:ring-primary focus:border-primary"
-              placeholder="戦略の説明を入力"
-              value={description}
-              onChange={(e) => setDescription(e.target.value)}
-            ></textarea>
-          </div>
-          <button type="submit" className="mt-4 bg-primary text-primary-content py-2 px-4 rounded">
+          <StrategyEditor value={strategy} onChange={setStrategy} />
+          <button
+            type="submit"
+            className="mt-4 bg-primary text-primary-content py-2 px-4 rounded"
+          >
             作成
           </button>
         </form>


### PR DESCRIPTION
## Summary
- ensure StrategyEditor sets default template properties
- show generated code in tabbed editors
- add regression test for empty template

## Testing
- `npm test --silent` *(fails: vitest not found)*
- `npm run lint --silent` *(fails: cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6856836442508320a7dff7aae8392bfa