### PR TITLE
Add validation to create strategy API

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,6 +12,7 @@ FX の戦略を開発するためのアプリケーションです。
 ## api プロジェクト
 
 C# & Azure Functions のアプリケーションです。backend/ の代わりに開発を進めています。
+開発や修正を行った際は `dotnet test api/stratrack-backend.sln -c Release` を実行し、テストが成功することを確認してください。
 
 ## backend プロジェクト
 

--- a/api/Stratrack.Api.Tests/StrategyFunctionsTests.cs
+++ b/api/Stratrack.Api.Tests/StrategyFunctionsTests.cs
@@ -90,6 +90,25 @@ public class StrategyFunctionsTests
     }
 
     [TestMethod]
+    public async Task PostStrategy_Returns422WhenNameEmpty()
+    {
+        var serviceProvider = CreateProvider();
+        var function = serviceProvider.GetRequiredService<StrategyFunctions>();
+
+        var request = new HttpRequestDataBuilder()
+            .WithUrl("http://localhost/api/strategies")
+            .WithMethod(HttpMethod.Post)
+            .WithBody(JsonSerializer.Serialize(new StrategyCreateRequest()
+            {
+                Name = string.Empty,
+            }))
+            .Build();
+
+        var response = await function.PostStrategy(request, CancellationToken.None).ConfigureAwait(false);
+        Assert.AreEqual(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+    }
+
+    [TestMethod]
     public async Task PostStrategy_SavesTemplate()
     {
         var serviceProvider = CreateProvider();

--- a/api/Stratrack.Api.Tests/StrategyFunctionsTests.cs
+++ b/api/Stratrack.Api.Tests/StrategyFunctionsTests.cs
@@ -227,4 +227,27 @@ public class StrategyFunctionsTests
         var obj = await response.ReadAsJsonAsync<StrategyDetail>().ConfigureAwait(false);
         Assert.AreEqual("Strategy 1 Edited", obj.Name);
     }
+
+    [TestMethod]
+    public async Task PutStrategy_Returns422WhenNameEmpty()
+    {
+        var serviceProvider = CreateProvider();
+        var function = serviceProvider.GetRequiredService<StrategyFunctions>();
+        var id = await CreateStrategyAsync(function, new StrategyCreateRequest()
+        {
+            Name = "name",
+        }).ConfigureAwait(false);
+
+        var request = new HttpRequestDataBuilder()
+            .WithUrl($"http://localhost/api/strategies/{id}")
+            .WithMethod(HttpMethod.Put)
+            .WithBody(JsonSerializer.Serialize(new StrategyUpdateRequest()
+            {
+                Name = string.Empty,
+            }))
+            .Build();
+
+        var response = await function.PutStrategy(request, id, CancellationToken.None).ConfigureAwait(false);
+        Assert.AreEqual(HttpStatusCode.UnprocessableEntity, response.StatusCode);
+    }
 }

--- a/api/Stratrack.Api/Functions/StrategyFunctions.cs
+++ b/api/Stratrack.Api/Functions/StrategyFunctions.cs
@@ -9,6 +9,7 @@ using Stratrack.Api.Domain.Strategies;
 using Stratrack.Api.Domain.Strategies.Commands;
 using Stratrack.Api.Domain.Strategies.Queries;
 using Stratrack.Api.Models;
+using System.ComponentModel.DataAnnotations;
 using System.Net;
 
 namespace Stratrack.Api.Functions;
@@ -50,6 +51,14 @@ public class StrategyFunctions(ICommandBus commandBus, IQueryProcessor queryProc
         if (body == null)
         {
             return req.CreateResponse(HttpStatusCode.UnprocessableEntity);
+        }
+
+        var validationResults = new List<ValidationResult>();
+        if (!Validator.TryValidateObject(body, new ValidationContext(body), validationResults, true))
+        {
+            var errorResponse = req.CreateResponse(HttpStatusCode.UnprocessableEntity);
+            await errorResponse.WriteAsJsonAsync(validationResults, token).ConfigureAwait(false);
+            return errorResponse;
         }
 
         var id = StrategyId.New;

--- a/api/Stratrack.Api/Functions/StrategyFunctions.cs
+++ b/api/Stratrack.Api/Functions/StrategyFunctions.cs
@@ -114,6 +114,13 @@ public class StrategyFunctions(ICommandBus commandBus, IQueryProcessor queryProc
         {
             return req.CreateResponse(HttpStatusCode.UnprocessableEntity);
         }
+        var validationResults = new List<ValidationResult>();
+        if (!Validator.TryValidateObject(body, new ValidationContext(body), validationResults, true))
+        {
+            var errorResponse = req.CreateResponse(HttpStatusCode.UnprocessableEntity);
+            await errorResponse.WriteAsJsonAsync(validationResults, token).ConfigureAwait(false);
+            return errorResponse;
+        }
         var id = StrategyId.With(Guid.Parse(strategyId));
         var target = await QueryStrategyDetail(StrategyId.With(Guid.Parse(strategyId)), token).ConfigureAwait(false);
         if (target == null)

--- a/api/Stratrack.Api/Models/StrategyCreateRequest.cs
+++ b/api/Stratrack.Api/Models/StrategyCreateRequest.cs
@@ -1,7 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Stratrack.Api.Models;
 
 public class StrategyCreateRequest
 {
+    [Required]
+    [MinLength(1)]
     public string Name { get; set; } = "";
     public string? Description { get; set; }
     public List<string> Tags { get; set; } = [];

--- a/api/Stratrack.Api/Models/StrategyUpdateRequest.cs
+++ b/api/Stratrack.Api/Models/StrategyUpdateRequest.cs
@@ -1,7 +1,11 @@
+using System.ComponentModel.DataAnnotations;
+
 namespace Stratrack.Api.Models;
 
 public class StrategyUpdateRequest
 {
+    [Required]
+    [MinLength(1)]
     public string Name { get; set; } = "";
     public string? Description { get; set; }
     public List<string> Tags { get; set; } = [];


### PR DESCRIPTION
## Summary
- validate `StrategyCreateRequest.Name` with DataAnnotations
- check validation results in `PostStrategy`
- return 422 when `Name` is empty
- test the new validation behavior

## Testing
- `dotnet test api/stratrack-backend.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6857342327288320b05ffbf1fb61f1b8