### PR TITLE
Add command bus failure handling

### DIFF
--- a/api/Stratrack.Api.Tests/FailingCommandBus.cs
+++ b/api/Stratrack.Api.Tests/FailingCommandBus.cs
@@ -1,0 +1,22 @@
+using System.Threading;
+using System.Threading.Tasks;
+using EventFlow;
+using EventFlow.Aggregates;
+using EventFlow.Aggregates.ExecutionResults;
+using EventFlow.Commands;
+using EventFlow.Core;
+
+namespace Stratrack.Api.Tests;
+
+public class FailingCommandBus : ICommandBus
+{
+    public Task<TExecutionResult> PublishAsync<TAggregate, TIdentity, TExecutionResult>(
+        ICommand<TAggregate, TIdentity, TExecutionResult> command,
+        CancellationToken cancellationToken)
+        where TAggregate : IAggregateRoot<TIdentity>
+        where TIdentity : IIdentity
+        where TExecutionResult : IExecutionResult
+    {
+        return Task.FromException<TExecutionResult>(new Exception("fail"));
+    }
+}


### PR DESCRIPTION
## Summary
- wrap command bus publishes in try/catch blocks
- log exceptions and return HTTP 500 with a JSON error object
- add `FailingCommandBus` stub for tests
- test that a failed command bus results in Internal Server Error

## Testing
- `dotnet test api/Stratrack.Api.Tests/Stratrack.Api.Tests.csproj -nologo`

------
https://chatgpt.com/codex/tasks/task_e_6857344661a48320a411531e71665b43