### PR TITLE
Fix infinite update loop in Strategy tests

### DIFF
--- a/frontend/src/features/strategies/StrategyEditor.tsx
+++ b/frontend/src/features/strategies/StrategyEditor.tsx
@@ -21,11 +21,13 @@ function StrategyEditor({ value, onChange }: StrategyEditorProps) {
   const setValue = useStore((s) => s.setValue);
   const update = useStore((s) => s.update);
 
+  // initialize store value from prop when the component mounts or when the
+  // provided value changes from the outside
   useEffect(() => {
-    if (value && value !== localValue) {
+    if (value) {
       setValue(value);
     }
-  }, [value, localValue, setValue]);
+  }, [value, setValue]);
 
   useEffect(() => {
     if (onChange) {


### PR DESCRIPTION
## Summary
- rework `useLocalValue` hook to avoid repeated updates
- initialize `StrategyEditor` store only when the prop changes

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6857b36bc5488320b1755569b5724fe7