### PR TITLE
Add strategy detail view

### DIFF
--- a/frontend/src/api/strategies.test.ts
+++ b/frontend/src/api/strategies.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { createStrategy } from "./strategies";
+import { createStrategy, updateStrategy } from "./strategies";
 
 describe("createStrategy", () => {
   it("serializes template without ValueKind", async () => {
@@ -12,6 +12,24 @@ describe("createStrategy", () => {
     const template = { foo: [] };
 
     await createStrategy({ name: "s", template });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.template.foo.ValueKind).toBeUndefined();
+    expect(body.template.foo).toEqual([]);
+  });
+});
+
+describe("updateStrategy", () => {
+  it("serializes template without ValueKind", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ id: "1" }),
+    });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const template = { foo: [] };
+
+    await updateStrategy("1", { name: "s", template });
 
     const body = JSON.parse(fetchMock.mock.calls[0][1].body);
     expect(body.template.foo.ValueKind).toBeUndefined();

--- a/frontend/src/api/strategies.ts
+++ b/frontend/src/api/strategies.ts
@@ -74,3 +74,17 @@ export async function createStrategy(data: NewStrategyRequest) {
   }
   return res.json();
 }
+
+export type UpdateStrategyRequest = NewStrategyRequest;
+
+export async function updateStrategy(id: string, data: UpdateStrategyRequest) {
+  const res = await fetch(`${API_BASE_URL}/api/strategies/${id}`, {
+    method: "PUT",
+    headers: { "Content-Type": "application/json", "x-functions-key": API_KEY },
+    body: JSON.stringify(toPlain(data)),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to update strategy: ${res.status}`);
+  }
+  return res.json();
+}

--- a/frontend/src/features/strategies/StrategyDetail.stories.tsx
+++ b/frontend/src/features/strategies/StrategyDetail.stories.tsx
@@ -1,8 +1,14 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { MemoryRouter } from "react-router-dom";
 import StrategyDetail from "./StrategyDetail";
 
 const meta = {
   component: StrategyDetail,
+  render: (args) => (
+    <MemoryRouter>
+      <StrategyDetail {...args} />
+    </MemoryRouter>
+  ),
   args: {
     strategy: {
       id: "1",

--- a/frontend/src/features/strategies/StrategyDetail.stories.tsx
+++ b/frontend/src/features/strategies/StrategyDetail.stories.tsx
@@ -1,0 +1,23 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import StrategyDetail from "./StrategyDetail";
+
+const meta = {
+  component: StrategyDetail,
+  args: {
+    strategy: {
+      id: "1",
+      name: "Sample Strategy",
+      description: "Example description",
+      tags: ["tag1", "tag2"],
+      template: { foo: "bar" },
+      generatedCode: "print('hello')",
+      createdAt: "",
+      updatedAt: "",
+    },
+  },
+} satisfies Meta<typeof StrategyDetail>;
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};

--- a/frontend/src/features/strategies/StrategyDetail.tsx
+++ b/frontend/src/features/strategies/StrategyDetail.tsx
@@ -32,7 +32,7 @@ export default function StrategyDetail({ strategy }: StrategyDetailProps) {
 
       <section>
         <h3 className="text-lg font-semibold mb-2">テンプレート</h3>
-        <pre className="bg-gray-100 p-4 rounded overflow-auto whitespace-pre-wrap">
+        <pre className="bg-gray-100 text-black p-2 rounded overflow-auto whitespace-pre-wrap">
           {JSON.stringify(strategy.template, null, 2)}
         </pre>
       </section>

--- a/frontend/src/features/strategies/StrategyDetail.tsx
+++ b/frontend/src/features/strategies/StrategyDetail.tsx
@@ -1,0 +1,44 @@
+import CodeEditor from "../../components/CodeEditor";
+import type { StrategyDetail as StrategyDetailType } from "../../api/strategies";
+
+export type StrategyDetailProps = {
+  strategy: StrategyDetailType;
+};
+
+export default function StrategyDetail({ strategy }: StrategyDetailProps) {
+  return (
+    <div className="space-y-6">
+      <header className="flex justify-between items-center">
+        <h2 className="text-2xl font-bold">{strategy.name}</h2>
+      </header>
+
+      <section>
+        <h3 className="text-lg font-semibold mb-2">説明</h3>
+        <p className="whitespace-pre-wrap">{strategy.description ?? "(なし)"}</p>
+        {strategy.tags.length > 0 && (
+          <p className="mt-2 space-x-2">
+            {strategy.tags.map((t) => (
+              <span key={t} className="badge badge-neutral">
+                {t}
+              </span>
+            ))}
+          </p>
+        )}
+      </section>
+
+      <section>
+        <h3 className="text-lg font-semibold mb-2">テンプレート</h3>
+        <pre className="bg-gray-100 p-4 rounded overflow-auto whitespace-pre-wrap">
+          {JSON.stringify(strategy.template, null, 2)}
+        </pre>
+      </section>
+
+      {strategy.generatedCode && (
+        <section>
+          <h3 className="text-lg font-semibold mb-2">変換コード</h3>
+          <CodeEditor language="python" value={strategy.generatedCode} readOnly />
+        </section>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/features/strategies/StrategyDetail.tsx
+++ b/frontend/src/features/strategies/StrategyDetail.tsx
@@ -1,3 +1,4 @@
+import { Link } from "react-router-dom";
 import CodeEditor from "../../components/CodeEditor";
 import type { StrategyDetail as StrategyDetailType } from "../../api/strategies";
 
@@ -10,6 +11,9 @@ export default function StrategyDetail({ strategy }: StrategyDetailProps) {
     <div className="space-y-6">
       <header className="flex justify-between items-center">
         <h2 className="text-2xl font-bold">{strategy.name}</h2>
+        <Link to={`/strategies/${strategy.id}/edit`} className="btn btn-sm btn-primary">
+          編集
+        </Link>
       </header>
 
       <section>

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -2,6 +2,7 @@ import Layout from "../components/SidebarLayout";
 import Dashboard from "./dashboard";
 import Strategies from "./strategies";
 import StrategyDetails from "./strategies/show";
+import EditStrategy from "./strategies/edit";
 import NewStrategy from "./strategies/new";
 import Backtest from "./backtesting";
 import DataSources from "./datasources";
@@ -15,6 +16,7 @@ export const routes = [
       { index: true, element: <Dashboard /> },
       { path: "strategies", element: <Strategies /> },
       { path: "strategies/:strategyId", element: <StrategyDetails /> },
+      { path: "strategies/:strategyId/edit", element: <EditStrategy /> },
       { path: "strategies-new", element: <NewStrategy /> },
       { path: "backtest", element: <Backtest /> },
       { path: "data-sources", element: <DataSources /> },

--- a/frontend/src/routes/strategies/edit.stories.tsx
+++ b/frontend/src/routes/strategies/edit.stories.tsx
@@ -1,0 +1,37 @@
+import { RouterProvider, createMemoryRouter } from "react-router-dom";
+import type { Meta, StoryObj } from "@storybook/react";
+import { within, expect } from "storybook/test";
+import EditStrategy from "./edit";
+
+const sample = {
+  id: "1",
+  name: "Sample",
+  description: "desc",
+  tags: [],
+  template: {},
+  createdAt: "",
+  updatedAt: "",
+};
+
+const meta = {
+  component: EditStrategy,
+  render: () => {
+    window.fetch = async () => ({ ok: true, json: async () => sample }) as Response;
+    const router = createMemoryRouter([{ path: "/:strategyId/edit", element: <EditStrategy /> }], {
+      initialEntries: ["/1/edit"],
+    });
+    return <RouterProvider router={router} />;
+  },
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof EditStrategy>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("戦略編集")).toBeInTheDocument();
+  },
+};

--- a/frontend/src/routes/strategies/edit.tsx
+++ b/frontend/src/routes/strategies/edit.tsx
@@ -1,0 +1,82 @@
+import { FormEvent, useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { getStrategy, updateStrategy } from "../../api/strategies";
+import StrategyEditor from "../../features/strategies/StrategyEditor";
+import { Strategy, StrategyTemplate } from "../../codegen/dsl/strategy";
+import { renderStrategyCode } from "../../codegen/generators/strategyCodeRenderer";
+import { useIndicatorList } from "../../features/indicators/IndicatorProvider";
+
+const EditStrategy = () => {
+  const { strategyId } = useParams<{ strategyId: string }>();
+  const [strategy, setStrategy] = useState<Partial<Strategy> | null>(null);
+  const indicators = useIndicatorList();
+  const navigate = useNavigate();
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (strategyId) {
+      getStrategy(strategyId)
+        .then((s) => setStrategy(s as unknown as Partial<Strategy>))
+        .catch((err) => console.error(err));
+    }
+  }, [strategyId]);
+
+  if (!strategy) {
+    return <p className="p-6">Loading...</p>;
+  }
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!strategyId || !strategy.name || !strategy.template) {
+      return;
+    }
+
+    setIsSubmitting(true);
+    setError(null);
+    const generatedCode = renderStrategyCode(
+      "python",
+      strategy.template as StrategyTemplate,
+      indicators
+    );
+    try {
+      await updateStrategy(strategyId, {
+        name: strategy.name,
+        description: strategy.description,
+        tags: strategy.tags,
+        template: strategy.template as Record<string, unknown>,
+        generatedCode,
+      });
+      navigate(`/strategies/${strategyId}`);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="p-6 space-y-6">
+      <header className="flex justify-between items-center">
+        <h2 className="text-2xl font-bold">戦略編集</h2>
+      </header>
+
+      <section>
+        <h3 className="text-lg font-semibold mb-2">戦略の詳細を編集してください</h3>
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          {error && <p className="text-error">{error}</p>}
+          <StrategyEditor value={strategy} onChange={setStrategy} />
+          <button
+            type="submit"
+            className="mt-4 bg-primary text-primary-content py-2 px-4 rounded"
+            disabled={isSubmitting}
+          >
+            更新
+          </button>
+        </form>
+      </section>
+    </div>
+  );
+};
+
+export default EditStrategy;

--- a/frontend/src/routes/strategies/show.tsx
+++ b/frontend/src/routes/strategies/show.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import { getStrategy, StrategyDetail } from "../../api/strategies";
+import StrategyDetailView from "../../features/strategies/StrategyDetail";
 
 const StrategyDetails = () => {
   const { strategyId } = useParams<{ strategyId: string }>();
@@ -20,14 +21,7 @@ const StrategyDetails = () => {
 
   return (
     <div className="p-6 space-y-6">
-      <header className="flex justify-between items-center">
-        <h2 className="text-2xl font-bold">{strategy.name}</h2>
-      </header>
-
-      <section>
-        <h3 className="text-lg font-semibold mb-2">説明</h3>
-        <p className="whitespace-pre-wrap">{strategy.description ?? "(なし)"}</p>
-      </section>
+      <StrategyDetailView strategy={strategy} />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- add `StrategyDetail` component under features/strategies
- show template info and generated code
- add Storybook story for new component
- display `StrategyDetail` in strategy details page

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68584b1b94e883209ae8cff98abe848e