### PR TITLE
Add relative timeframe support

### DIFF
--- a/frontend/src/codegen/dsl/common.ts
+++ b/frontend/src/codegen/dsl/common.ts
@@ -9,7 +9,7 @@ export type ScalarExpression =
   | ScalarBinaryOperationExpression
   | ScalarTernaryExpression;
 
-export type VariableDataType = "scalar" | "array" | "parameter" | "timeframe";
+export type VariableDataType = "string" | "number" | "series" | "timeframe";
 export type BarExpression = PriceExpression | SourceExpression | VariableReferenceExpression;
 
 export type ConstantExpression = {
@@ -34,6 +34,7 @@ export type VariableReferenceExpression = {
 
 export type TimeframeExpression =
   | { type: "constant"; value: string }
+  | { type: "higher_timeframe"; level: number }
   | ParamReferenceExpression
   | VariableReferenceExpression;
 

--- a/frontend/src/codegen/ir/ast.ts
+++ b/frontend/src/codegen/ir/ast.ts
@@ -40,12 +40,13 @@ export type IRIndicatorParamValue = {
 
 export type IRTimeframeExpression =
   | { type: "constant"; value: string }
+  | { type: "higher_timeframe"; level: number }
   | IRVariableRef
   | IRConstantParamRef;
 
 export type IRVariable = {
   name: string;
-  dataType?: "scalar" | "array" | "parameter" | "timeframe";
+  dataType?: "string" | "number" | "series" | "timeframe";
   timeframe?: IRTimeframeExpression;
   expression: IRExpression;
   invalidPeriod?: IRExpression;

--- a/frontend/src/codegen/ir/builder.ts
+++ b/frontend/src/codegen/ir/builder.ts
@@ -182,6 +182,8 @@ function mapTimeframeExpression(
   switch (tf.type) {
     case "constant":
       return { type: "constant", value: tf.value };
+    case "higher_timeframe":
+      return { type: "higher_timeframe", level: tf.level };
     case "param":
       return { type: "constant_param_ref", name: tf.name };
     case "variable":

--- a/frontend/src/codegen/mql/emit/emitExpr.test.ts
+++ b/frontend/src/codegen/mql/emit/emitExpr.test.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from "vitest";
+import { IRExpression } from "../../ir/ast";
+import { emitMqlExprFromIR } from "./emitExpr";
+import { access, binary, call, lit, ref, unary } from "../helper";
+
+describe("emitMqlExprFromIR higher timeframe", () => {
+  it("adjusts variable reference index", () => {
+    const expr: IRExpression = {
+      type: "variable_ref",
+      name: "seriesVar",
+      timeframe: { type: "higher_timeframe", level: 1 },
+    };
+    const result = emitMqlExprFromIR("strategy", expr, lit(10));
+    expect(result).toEqual(
+      access(ref("seriesVar"), unary("-", binary("/", lit(10), lit(5))), false)
+    );
+  });
+
+  it("emits price reference with higher timeframe", () => {
+    const expr: IRExpression = {
+      type: "price_ref",
+      source: "close",
+      timeframe: { type: "higher_timeframe", level: 1 },
+    };
+    const result = emitMqlExprFromIR("strategy", expr, lit(10));
+    expect(result).toEqual(
+      call("iClose", [lit("Symbol()"), ref("PERIOD_M5"), binary("/", lit(10), lit(5))])
+    );
+  });
+
+  it("handles bar_shift with higher timeframe", () => {
+    const expr: IRExpression = {
+      type: "bar_shift",
+      source: { type: "price_ref", source: "close" },
+      shiftBar: { type: "constant", value: 3 },
+      timeframe: { type: "higher_timeframe", level: 1 },
+    };
+    const result = emitMqlExprFromIR("strategy", expr);
+    expect(result).toEqual(access(ref("Close"), binary("/", lit(3), lit(5)), false, lit(0)));
+  });
+});

--- a/frontend/src/codegen/python/emit/index.ts
+++ b/frontend/src/codegen/python/emit/index.ts
@@ -3,6 +3,7 @@ import { PyModule, PyStatement } from "../ast";
 import { assign, attr, bin, call, comment, forStmt, imp, lit, mod, ref, stmt } from "../helper";
 import { emitBtIndicatorFromIR } from "./emitIndicator";
 import { emitBtStrategyFromIR } from "./emitStrategy";
+import { BASE_TIMEFRAME } from "./emitExpr";
 
 export function emitBtProgramFromIR(program: IRProgram): PyModule {
   const indicators = program.indicatorDefs.map((i) => emitBtIndicatorFromIR(i));
@@ -13,7 +14,12 @@ export function emitBtProgramFromIR(program: IRProgram): PyModule {
     comment("Create a cerebro entity"),
     assign(ref("cerebro"), call(ref("bt.Cerebro"), [])),
     comment("Add a strategy"),
-    stmt(call(attr(ref("cerebro"), "addstrategy"), [ref(strategy.name)])),
+    stmt(
+      call(attr(ref("cerebro"), "addstrategy"), [
+        ref(strategy.name),
+        ref(`base_timeframe='${BASE_TIMEFRAME}'`),
+      ])
+    ),
     comment("data is relative to the script location"),
     assign(
       ref("modpath"),

--- a/frontend/src/codegen/utils/timeframe.ts
+++ b/frontend/src/codegen/utils/timeframe.ts
@@ -1,0 +1,51 @@
+export const TIMEFRAME_MINUTES: Record<string, number> = {
+  "1m": 1,
+  "5m": 5,
+  "15m": 15,
+  "30m": 30,
+  "1h": 60,
+  "2h": 120,
+  "4h": 240,
+  "1d": 1440,
+};
+
+export function timeframeToMinutes(tf: string): number {
+  return TIMEFRAME_MINUTES[tf] ?? 1;
+}
+
+export function resolveHigherTimeframe(base: string, level: number): string {
+  const order = Object.keys(TIMEFRAME_MINUTES);
+  const index = order.indexOf(base);
+  const next = index + level;
+  return order[Math.min(order.length - 1, Math.max(0, next))] || base;
+}
+import { IRTimeframeExpression } from "../ir/ast";
+
+export function resolveTimeframeExpression(
+  expr: IRTimeframeExpression | undefined,
+  base: string
+): string {
+  if (!expr) return base;
+  switch (expr.type) {
+    case "constant":
+      return expr.value;
+    case "higher_timeframe":
+      return resolveHigherTimeframe(base, expr.level);
+    default:
+      return base;
+  }
+}
+
+export function timeframeToPeriod(tf: string): string {
+  const map: Record<string, string> = {
+    "1m": "PERIOD_M1",
+    "5m": "PERIOD_M5",
+    "15m": "PERIOD_M15",
+    "30m": "PERIOD_M30",
+    "1h": "PERIOD_H1",
+    "2h": "PERIOD_H2",
+    "4h": "PERIOD_H4",
+    "1d": "PERIOD_D1",
+  };
+  return map[tf] ?? "PERIOD_CURRENT";
+}

--- a/frontend/src/features/strategies/components/StrategyConditionOperandSelector.tsx
+++ b/frontend/src/features/strategies/components/StrategyConditionOperandSelector.tsx
@@ -205,7 +205,7 @@ function ArrayVariableConditionOperandSelector({
   value,
   onChange,
 }: ArrayVariableConditionOperandSelectorProps) {
-  const variables = useVariables().filter((v) => v.dataType === "array");
+  const variables = useVariables().filter((v) => v.dataType === "series");
   return (
     <Select
       fullWidth

--- a/frontend/src/features/strategies/components/TimeframeEditor.stories.tsx
+++ b/frontend/src/features/strategies/components/TimeframeEditor.stories.tsx
@@ -37,3 +37,9 @@ export const Variable: Story = {
     value: { type: "variable", name: "tfVar" },
   },
 };
+
+export const Higher: Story = {
+  args: {
+    value: { type: "higher_timeframe", level: 1 },
+  },
+};

--- a/frontend/src/features/strategies/components/TimeframeEditor.tsx
+++ b/frontend/src/features/strategies/components/TimeframeEditor.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import Select from "../../../components/Select";
+import NumberInput from "../../../components/NumberInput";
 import { TimeframeExpression } from "../../../codegen/dsl/common";
 import { useLocalValue } from "../../../hooks/useLocalValue";
 import { useVariables } from "./useVariables";
@@ -13,6 +14,7 @@ export type TimeframeEditorProps = {
 const TYPE_OPTIONS = [
   { value: "constant", label: "固定" },
   { value: "variable", label: "変数" },
+  { value: "higher_timeframe", label: "上位足" },
 ];
 
 const TIMEFRAME_OPTIONS = [
@@ -43,8 +45,10 @@ const TimeframeEditor: React.FC<TimeframeEditorProps> = ({ value, onChange, labe
             const type = val as TimeframeExpression["type"];
             if (type === "constant") {
               setLocalValue({ type: "constant", value: "1m" });
-            } else {
+            } else if (type === "variable") {
               setLocalValue({ type: "variable", name: variables[0]?.name || "" });
+            } else {
+              setLocalValue({ type: "higher_timeframe", level: 1 });
             }
           }}
           options={TYPE_OPTIONS}
@@ -68,6 +72,14 @@ const TimeframeEditor: React.FC<TimeframeEditorProps> = ({ value, onChange, labe
               value: v.name,
               label: `${v.name}${v.description ? ` (${v.description})` : ""}`,
             }))}
+          />
+        )}
+        {local.type === "higher_timeframe" && (
+          <NumberInput
+            fullWidth
+            value={local.level}
+            onChange={(val) => setLocalValue({ type: "higher_timeframe", level: val || 1 })}
+            label="上位足"
           />
         )}
       </div>

--- a/frontend/src/features/strategies/sections/Variables.tsx
+++ b/frontend/src/features/strategies/sections/Variables.tsx
@@ -24,9 +24,9 @@ function Variables({ value, onChange }: VariablesProps) {
   );
 
   const DATA_TYPE_OPTIONS = [
-    { value: "scalar", label: "スカラー" },
-    { value: "array", label: "配列" },
-    { value: "parameter", label: "パラメーター" },
+    { value: "string", label: "文字列" },
+    { value: "number", label: "数値" },
+    { value: "series", label: "数値配列" },
     { value: "timeframe", label: "時間足" },
   ];
 
@@ -37,7 +37,7 @@ function Variables({ value, onChange }: VariablesProps) {
         ...(localValue.variables || []),
         {
           name: "",
-          dataType: "scalar" as VariableDataType,
+          dataType: "number" as VariableDataType,
           timeframe: undefined,
           expression: { type: "constant", value: 0 },
         },
@@ -72,7 +72,7 @@ function Variables({ value, onChange }: VariablesProps) {
             <Select
               fullWidth
               label="データ型"
-              value={variable.dataType || "scalar"}
+              value={variable.dataType || "number"}
               onChange={(val) =>
                 handleUpdate(index, {
                   ...variable,


### PR DESCRIPTION
## Summary
- remove obsolete param-var-types doc
- add higher_timeframe expression type
- track variable data types as string/number/series/timeframe
- update UI components to handle relative timeframe and new data types

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685b571c936c8320aefc2d09d0654401