### PR TITLE
Implement LZMA-based Dukascopy client

### DIFF
--- a/api/Stratrack.Api/Domain/ServiceCollectionExtension.cs
+++ b/api/Stratrack.Api/Domain/ServiceCollectionExtension.cs
@@ -88,7 +88,7 @@ public static class ServiceCollectionExtension
             {
                 s.AddSingleton<IBlobStorage, DatabaseBlobStorage>();
                 s.AddSingleton<DataChunkReadModelLocator>();
-                s.AddSingleton<IDukascopyClient, StubDukascopyClient>();
+                s.AddSingleton<IDukascopyClient, DukascopyClient>();
                 s.AddSingleton<DukascopyFetchService>();
             });
         });

--- a/api/Stratrack.Api/Infrastructure/DukascopyClient.cs
+++ b/api/Stratrack.Api/Infrastructure/DukascopyClient.cs
@@ -1,11 +1,11 @@
 using System.Buffers.Binary;
-using System.Diagnostics;
+using LzmaDecoder = SevenZip.Compression.LZMA.Decoder;
 using System.Text;
 using Stratrack.Api.Domain.Dukascopy;
 
 namespace Stratrack.Api.Infrastructure;
 
-public class StubDukascopyClient : IDukascopyClient
+public class DukascopyClient : IDukascopyClient
 {
     private readonly HttpClient _http = new();
 
@@ -15,18 +15,16 @@ public class StubDukascopyClient : IDukascopyClient
         var url = $"https://datafeed.dukascopy.com/datafeed/{symbol}/{baseTime:yyyy}/{baseTime:MM}/{baseTime:dd}/{baseTime:HH}h_ticks.bi5";
         var compressed = await _http.GetByteArrayAsync(url, token).ConfigureAwait(false);
 
-        var psi = new ProcessStartInfo("lzma", "-dc")
-        {
-            RedirectStandardInput = true,
-            RedirectStandardOutput = true,
-            UseShellExecute = false
-        };
-        using var proc = Process.Start(psi)!;
-        await proc.StandardInput.BaseStream.WriteAsync(compressed, token).ConfigureAwait(false);
-        proc.StandardInput.Close();
+        using var inStream = new MemoryStream(compressed);
+        var properties = new byte[5];
+        await inStream.ReadAsync(properties, token).ConfigureAwait(false);
+        var decoder = new LzmaDecoder();
+        decoder.SetDecoderProperties(properties);
+        var outSizeBytes = new byte[8];
+        await inStream.ReadAsync(outSizeBytes, token).ConfigureAwait(false);
+        var outSize = BitConverter.ToInt64(outSizeBytes, 0);
         using var decompressed = new MemoryStream();
-        await proc.StandardOutput.BaseStream.CopyToAsync(decompressed, token).ConfigureAwait(false);
-        await proc.WaitForExitAsync(token).ConfigureAwait(false);
+        decoder.Code(inStream, decompressed, inStream.Length - inStream.Position, outSize, null);
 
         var span = decompressed.ToArray();
         var sb = new StringBuilder();

--- a/api/Stratrack.Api/Stratrack.Api.csproj
+++ b/api/Stratrack.Api/Stratrack.Api.csproj
@@ -18,6 +18,7 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.2" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="8.0.15" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="8.0.15" />
+    <PackageReference Include="LZMA-SDK" Version="22.1.1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">


### PR DESCRIPTION
## Summary
- implement `DukascopyClient` using LZMA decoder instead of shell command
- register the new client in DI
- add `LZMA-SDK` dependency for the client implementation

## Testing
- `dotnet build api/stratrack-backend.sln -c Release`
- `dotnet test api/stratrack-backend.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6860b936937c832084bd766b760b60a8