### PR TITLE
Add DataSource CRUD screens

### DIFF
--- a/api/Stratrack.Api/Models/TickFileUploadRequest.cs
+++ b/api/Stratrack.Api/Models/TickFileUploadRequest.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Stratrack.Api.Models;
+
+public class TickFileUploadRequest
+{
+    [Required]
+    public string FileName { get; set; } = "";
+
+    [Required]
+    public string Base64Data { get; set; } = "";
+}

--- a/frontend/src/api/datasources.test.ts
+++ b/frontend/src/api/datasources.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi } from "vitest";
+import { createDataSource, updateDataSource } from "./datasources";
+
+describe("createDataSource", () => {
+  it("serializes payload without ValueKind", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ id: "1" }) });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await createDataSource({
+      name: "ds",
+      symbol: "EURUSD",
+      timeframe: "1m",
+      sourceType: "dukascopy",
+    });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.symbol).toBe("EURUSD");
+  });
+});
+
+describe("updateDataSource", () => {
+  it("serializes payload without ValueKind", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ id: "1" }) });
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    await updateDataSource("1", { name: "ds" });
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body.name).toBe("ds");
+  });
+});

--- a/frontend/src/api/datasources.test.ts
+++ b/frontend/src/api/datasources.test.ts
@@ -1,31 +1,27 @@
 import { describe, it, expect, vi } from "vitest";
 import { createDataSource, updateDataSource } from "./datasources";
 
-describe("createDataSource", () => {
-  it("serializes payload without ValueKind", async () => {
+type DsFn = (data: any) => Promise<unknown>;
+
+const cases: [string, DsFn, () => any][] = [
+  [
+    "createDataSource",
+    createDataSource as unknown as DsFn,
+    () => ({ name: "ds", symbol: "EURUSD", timeframe: "1m", sourceType: "dukascopy" }),
+  ],
+  ["updateDataSource", (data) => updateDataSource("1", data as any), () => ({ name: "ds" })],
+];
+
+describe.each(cases)("%s", (_, fn, makeData) => {
+  it("sends plain JSON payload", async () => {
     const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ id: "1" }) });
     global.fetch = fetchMock as unknown as typeof fetch;
 
-    await createDataSource({
-      name: "ds",
-      symbol: "EURUSD",
-      timeframe: "1m",
-      sourceType: "dukascopy",
-    });
+    const data = makeData();
+
+    await fn(data);
 
     const body = JSON.parse(fetchMock.mock.calls[0][1].body);
-    expect(body.symbol).toBe("EURUSD");
-  });
-});
-
-describe("updateDataSource", () => {
-  it("serializes payload without ValueKind", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ id: "1" }) });
-    global.fetch = fetchMock as unknown as typeof fetch;
-
-    await updateDataSource("1", { name: "ds" });
-
-    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
-    expect(body.name).toBe("ds");
+    expect(body).toEqual(data);
   });
 });

--- a/frontend/src/api/datasources.test.ts
+++ b/frontend/src/api/datasources.test.ts
@@ -1,27 +1,37 @@
 import { describe, it, expect, vi } from "vitest";
 import { createDataSource, updateDataSource } from "./datasources";
 
-type DsFn = (data: any) => Promise<unknown>;
+const okResponse = { ok: true, json: async () => ({ id: "1" }) } as Response;
 
-const cases: [string, DsFn, () => any][] = [
-  [
-    "createDataSource",
-    createDataSource as unknown as DsFn,
-    () => ({ name: "ds", symbol: "EURUSD", timeframe: "1m", sourceType: "dukascopy" }),
-  ],
-  ["updateDataSource", (data) => updateDataSource("1", data as any), () => ({ name: "ds" })],
-];
-
-describe.each(cases)("%s", (_, fn, makeData) => {
+describe("createDataSource", () => {
   it("sends plain JSON payload", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ id: "1" }) });
+    const fetchMock = vi.fn().mockResolvedValue(okResponse);
     global.fetch = fetchMock as unknown as typeof fetch;
 
-    const data = makeData();
+    const data = {
+      name: "ds",
+      symbol: "EURUSD",
+      timeframe: "1m",
+      sourceType: "dukascopy",
+    };
 
-    await fn(data);
+    await createDataSource(data);
 
-    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body).toEqual(data);
+  });
+});
+
+describe("updateDataSource", () => {
+  it("sends plain JSON payload", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const data = { name: "ds" };
+
+    await updateDataSource("1", data);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
     expect(body).toEqual(data);
   });
 });

--- a/frontend/src/api/datasources.ts
+++ b/frontend/src/api/datasources.ts
@@ -1,0 +1,101 @@
+export type NewDataSourceRequest = {
+  name: string;
+  symbol: string;
+  timeframe: string;
+  sourceType: string;
+  description?: string;
+};
+
+export type DataSourceSummary = {
+  id: string;
+  name: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+export type DataSourceDetail = {
+  id: string;
+  name: string;
+  symbol: string;
+  timeframe: string;
+  sourceType: string;
+  description?: string;
+  createdAt: string;
+  updatedAt: string;
+};
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "";
+const API_KEY = import.meta.env.VITE_API_KEY ?? "";
+
+export async function listDataSources(): Promise<DataSourceSummary[]> {
+  const res = await fetch(`${API_BASE_URL}/api/data-sources`, {
+    headers: { "x-functions-key": API_KEY },
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch data sources: ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function getDataSource(id: string): Promise<DataSourceDetail> {
+  const res = await fetch(`${API_BASE_URL}/api/data-sources/${id}`, {
+    headers: { "x-functions-key": API_KEY },
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch data source: ${res.status}`);
+  }
+  return res.json();
+}
+
+function toPlain<T>(value: T): T {
+  try {
+    return structuredClone(value);
+  } catch {
+    return JSON.parse(JSON.stringify(value));
+  }
+}
+
+export async function createDataSource(data: NewDataSourceRequest) {
+  const res = await fetch(`${API_BASE_URL}/api/data-sources`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-functions-key": API_KEY,
+    },
+    body: JSON.stringify(toPlain(data)),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to create data source: ${res.status}`);
+  }
+  return res.json();
+}
+
+export type UpdateDataSourceRequest = {
+  name: string;
+  description?: string;
+};
+
+export async function updateDataSource(id: string, data: UpdateDataSourceRequest) {
+  const res = await fetch(`${API_BASE_URL}/api/data-sources/${id}`, {
+    method: "PUT",
+    headers: {
+      "Content-Type": "application/json",
+      "x-functions-key": API_KEY,
+    },
+    body: JSON.stringify(toPlain(data)),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to update data source: ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function deleteDataSource(id: string) {
+  const res = await fetch(`${API_BASE_URL}/api/data-sources/${id}`, {
+    method: "DELETE",
+    headers: { "x-functions-key": API_KEY },
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to delete data source: ${res.status}`);
+  }
+}

--- a/frontend/src/api/strategies.test.ts
+++ b/frontend/src/api/strategies.test.ts
@@ -1,38 +1,30 @@
 import { describe, it, expect, vi } from "vitest";
 import { createStrategy, updateStrategy } from "./strategies";
 
-describe("createStrategy", () => {
-  it("serializes template without ValueKind", async () => {
+type StrategyFn = (data: Parameters<typeof createStrategy>[0]) => Promise<unknown>;
+
+const cases: [string, StrategyFn, () => Parameters<StrategyFn>[0]][] = [
+  ["createStrategy", createStrategy, () => ({ name: "s", template: { foo: [] } })],
+  [
+    "updateStrategy",
+    (data) => updateStrategy("1", data),
+    () => ({ name: "s", template: { foo: [] } }),
+  ],
+];
+
+describe.each(cases)("%s", (_, fn, makeData) => {
+  it("sends plain JSON payload", async () => {
     const fetchMock = vi.fn().mockResolvedValue({
       ok: true,
       json: async () => ({ id: "1" }),
     });
     global.fetch = fetchMock as unknown as typeof fetch;
 
-    const template = { foo: [] };
+    const data = makeData();
 
-    await createStrategy({ name: "s", template });
-
-    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
-    expect(body.template.foo.ValueKind).toBeUndefined();
-    expect(body.template.foo).toEqual([]);
-  });
-});
-
-describe("updateStrategy", () => {
-  it("serializes template without ValueKind", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ id: "1" }),
-    });
-    global.fetch = fetchMock as unknown as typeof fetch;
-
-    const template = { foo: [] };
-
-    await updateStrategy("1", { name: "s", template });
+    await fn(data);
 
     const body = JSON.parse(fetchMock.mock.calls[0][1].body);
-    expect(body.template.foo.ValueKind).toBeUndefined();
-    expect(body.template.foo).toEqual([]);
+    expect(body).toEqual(data);
   });
 });

--- a/frontend/src/api/strategies.test.ts
+++ b/frontend/src/api/strategies.test.ts
@@ -1,30 +1,32 @@
 import { describe, it, expect, vi } from "vitest";
 import { createStrategy, updateStrategy } from "./strategies";
 
-type StrategyFn = (data: Parameters<typeof createStrategy>[0]) => Promise<unknown>;
+const okResponse = { ok: true, json: async () => ({ id: "1" }) } as Response;
 
-const cases: [string, StrategyFn, () => Parameters<StrategyFn>[0]][] = [
-  ["createStrategy", createStrategy, () => ({ name: "s", template: { foo: [] } })],
-  [
-    "updateStrategy",
-    (data) => updateStrategy("1", data),
-    () => ({ name: "s", template: { foo: [] } }),
-  ],
-];
-
-describe.each(cases)("%s", (_, fn, makeData) => {
+describe("createStrategy", () => {
   it("sends plain JSON payload", async () => {
-    const fetchMock = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({ id: "1" }),
-    });
+    const fetchMock = vi.fn().mockResolvedValue(okResponse);
     global.fetch = fetchMock as unknown as typeof fetch;
 
-    const data = makeData();
+    const data = { name: "s", template: { foo: [] } };
 
-    await fn(data);
+    await createStrategy(data);
 
-    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
+    expect(body).toEqual(data);
+  });
+});
+
+describe("updateStrategy", () => {
+  it("sends plain JSON payload", async () => {
+    const fetchMock = vi.fn().mockResolvedValue(okResponse);
+    global.fetch = fetchMock as unknown as typeof fetch;
+
+    const data = { name: "s", template: { foo: [] } };
+
+    await updateStrategy("1", data);
+
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body as string);
     expect(body).toEqual(data);
   });
 });

--- a/frontend/src/api/ticks.ts
+++ b/frontend/src/api/ticks.ts
@@ -1,0 +1,31 @@
+function toPlain<T>(value: T): T {
+  try {
+    return structuredClone(value);
+  } catch {
+    return JSON.parse(JSON.stringify(value));
+  }
+}
+
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "";
+const API_KEY = import.meta.env.VITE_API_KEY ?? "";
+
+type TickFileUploadRequest = {
+  fileName: string;
+  base64Data: string;
+};
+
+export async function uploadTickFile(dataSourceId: string, file: File) {
+  const buf = await file.arrayBuffer();
+  const base64Data = btoa(String.fromCharCode(...new Uint8Array(buf)));
+  const body: TickFileUploadRequest = { fileName: file.name, base64Data };
+
+  const res = await fetch(`${API_BASE_URL}/api/data-sources/${dataSourceId}/ticks/file`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-functions-key": API_KEY },
+    body: JSON.stringify(toPlain(body)),
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to upload tick file: ${res.status}`);
+  }
+  return res;
+}

--- a/frontend/src/features/datasources/DataSourceForm.stories.tsx
+++ b/frontend/src/features/datasources/DataSourceForm.stories.tsx
@@ -1,0 +1,21 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn, userEvent, within, expect } from "storybook/test";
+import DataSourceForm from "./DataSourceForm";
+
+const meta = {
+  component: DataSourceForm,
+  args: { onChange: fn() },
+} satisfies Meta<typeof DataSourceForm>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {},
+  play: async ({ canvasElement, args }) => {
+    const canvas = within(canvasElement);
+    await userEvent.type(canvas.getByLabelText("名称"), "test");
+    await expect(args.onChange).toHaveBeenCalled();
+  },
+};

--- a/frontend/src/features/datasources/DataSourceForm.tsx
+++ b/frontend/src/features/datasources/DataSourceForm.tsx
@@ -1,0 +1,89 @@
+import { useCallback } from "react";
+import Input from "../../components/Input";
+import Textarea from "../../components/Textarea";
+import { useLocalValue } from "../../hooks/useLocalValue";
+
+export type DataSourceFormValue = {
+  name?: string;
+  symbol?: string;
+  timeframe?: string;
+  sourceType?: string;
+  description?: string;
+};
+
+export type DataSourceFormProps = {
+  value?: DataSourceFormValue;
+  onChange?: (value: DataSourceFormValue) => void;
+  hideSourceFields?: boolean;
+};
+
+function DataSourceForm({ value, onChange, hideSourceFields = false }: DataSourceFormProps) {
+  const [localValue, setLocalValue] = useLocalValue<DataSourceFormValue>({}, value, onChange);
+
+  const handleNameChange = useCallback(
+    (v: string) => setLocalValue((cv) => ({ ...cv, name: v })),
+    [setLocalValue]
+  );
+  const handleSymbolChange = useCallback(
+    (v: string) => setLocalValue((cv) => ({ ...cv, symbol: v })),
+    [setLocalValue]
+  );
+  const handleTimeframeChange = useCallback(
+    (v: string) => setLocalValue((cv) => ({ ...cv, timeframe: v })),
+    [setLocalValue]
+  );
+  const handleSourceTypeChange = useCallback(
+    (v: string) => setLocalValue((cv) => ({ ...cv, sourceType: v })),
+    [setLocalValue]
+  );
+  const handleDescriptionChange = useCallback(
+    (v: string) => setLocalValue((cv) => ({ ...cv, description: v })),
+    [setLocalValue]
+  );
+
+  return (
+    <div className="space-y-4">
+      <Input
+        label="名称"
+        value={localValue.name || ""}
+        onChange={handleNameChange}
+        required
+        fullWidth
+      />
+      {!hideSourceFields && (
+        <>
+          <Input
+            label="通貨ペア"
+            value={localValue.symbol || ""}
+            onChange={handleSymbolChange}
+            required
+            fullWidth
+          />
+          <Input
+            label="時間足"
+            value={localValue.timeframe || ""}
+            onChange={handleTimeframeChange}
+            required
+            fullWidth
+          />
+          <Input
+            label="ソース種別"
+            value={localValue.sourceType || ""}
+            onChange={handleSourceTypeChange}
+            required
+            fullWidth
+          />
+        </>
+      )}
+      <Textarea
+        label="説明"
+        value={localValue.description || ""}
+        onChange={handleDescriptionChange}
+        rows={3}
+        fullWidth
+      />
+    </div>
+  );
+}
+
+export default DataSourceForm;

--- a/frontend/src/routes/datasources/edit.stories.tsx
+++ b/frontend/src/routes/datasources/edit.stories.tsx
@@ -1,0 +1,41 @@
+import { RouterProvider, createMemoryRouter } from "react-router-dom";
+import type { Meta, StoryObj } from "@storybook/react";
+import { within, expect } from "storybook/test";
+import EditDataSource from "./edit";
+
+const sample = {
+  id: "1",
+  name: "Sample",
+  symbol: "EURUSD",
+  timeframe: "1m",
+  sourceType: "dukascopy",
+  description: "desc",
+  createdAt: "",
+  updatedAt: "",
+};
+
+const meta = {
+  component: EditDataSource,
+  render: () => {
+    window.fetch = async () => ({ ok: true, json: async () => sample }) as Response;
+    const router = createMemoryRouter(
+      [{ path: "/:dataSourceId/edit", element: <EditDataSource /> }],
+      {
+        initialEntries: ["/1/edit"],
+      }
+    );
+    return <RouterProvider router={router} />;
+  },
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof EditDataSource>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("データソース編集")).toBeInTheDocument();
+  },
+};

--- a/frontend/src/routes/datasources/edit.tsx
+++ b/frontend/src/routes/datasources/edit.tsx
@@ -1,0 +1,103 @@
+import { FormEvent, useEffect, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import {
+  getDataSource,
+  updateDataSource,
+  deleteDataSource,
+  DataSourceDetail,
+} from "../../api/datasources";
+import DataSourceForm, { DataSourceFormValue } from "../../features/datasources/DataSourceForm";
+
+const EditDataSource = () => {
+  const { dataSourceId } = useParams<{ dataSourceId: string }>();
+  const [dataSource, setDataSource] = useState<DataSourceDetail | null>(null);
+  const navigate = useNavigate();
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  useEffect(() => {
+    if (dataSourceId) {
+      getDataSource(dataSourceId)
+        .then(setDataSource)
+        .catch((err) => console.error(err));
+    }
+  }, [dataSourceId]);
+
+  if (!dataSource) {
+    return <p className="p-6">Loading...</p>;
+  }
+
+  const handleFormChange = (value: DataSourceFormValue) => {
+    setDataSource((prev) => (prev ? { ...prev, ...value } : prev));
+  };
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!dataSourceId || !dataSource.name) {
+      return;
+    }
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      await updateDataSource(dataSourceId, {
+        name: dataSource.name,
+        description: dataSource.description,
+      });
+      navigate("/data-sources");
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleDelete = async () => {
+    if (!dataSourceId) {
+      return;
+    }
+    if (!confirm("本当に削除しますか？")) {
+      return;
+    }
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      await deleteDataSource(dataSourceId);
+      navigate("/data-sources");
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="p-6 space-y-6">
+      <header className="flex justify-between items-center">
+        <h2 className="text-2xl font-bold">データソース編集</h2>
+        <button
+          type="button"
+          className="btn btn-error"
+          onClick={handleDelete}
+          disabled={isSubmitting}
+        >
+          削除
+        </button>
+      </header>
+      <section>
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          {error && <p className="text-error">{error}</p>}
+          <DataSourceForm value={dataSource} onChange={handleFormChange} hideSourceFields />
+          <button
+            type="submit"
+            className="mt-4 bg-primary text-primary-content py-2 px-4 rounded"
+            disabled={isSubmitting}
+          >
+            更新
+          </button>
+        </form>
+      </section>
+    </div>
+  );
+};
+
+export default EditDataSource;

--- a/frontend/src/routes/datasources/index.tsx
+++ b/frontend/src/routes/datasources/index.tsx
@@ -1,28 +1,39 @@
-import { Link } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
+import { useEffect, useState } from "react";
+import { listDataSources, DataSourceSummary } from "../../api/datasources";
+import Button from "../../components/Button";
 
 const DataSources = () => {
+  const navigate = useNavigate();
+  const [dataSources, setDataSources] = useState<DataSourceSummary[]>([]);
+
+  useEffect(() => {
+    listDataSources()
+      .then(setDataSources)
+      .catch((err) => console.error(err));
+  }, []);
+
   return (
     <div className="p-6 space-y-6">
       <header className="flex justify-between items-center">
-        <h2 className="text-2xl font-bold">バックテスト</h2>
+        <h2 className="text-2xl font-bold">データソース</h2>
+        <Button onClick={() => navigate("/data-sources/new")}>＋ 新規作成</Button>
       </header>
 
       <section>
-        <h3 className="text-lg font-semibold mb-2">データソース</h3>
+        <h3 className="text-lg font-semibold mb-2">一覧</h3>
         <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {/* Sample Card */}
-          {[1, 2, 3].map((i) => (
-            <div key={i} className="rounded-xl border p-4 shadow">
-              <h4 className="font-bold">データソース {i}</h4>
-              <p className="text-sm text-gray-600">説明文をここに表示</p>
-              <Link
-                to={`/data-sources/${i}`}
-                className="mt-2 bg-primary text-primary-content py-1 px-3 rounded"
-              >
-                詳細
+          {dataSources.map((ds) => (
+            <div key={ds.id} className="rounded-xl border p-4 shadow">
+              <h4 className="font-bold">{ds.name}</h4>
+              <Link to={`/data-sources/${ds.id}/edit`} className="mt-2 btn btn-sm btn-primary">
+                編集
               </Link>
             </div>
           ))}
+          {dataSources.length === 0 && (
+            <p className="col-span-full text-center text-gray-500">データソースがありません</p>
+          )}
         </div>
       </section>
     </div>

--- a/frontend/src/routes/datasources/index.tsx
+++ b/frontend/src/routes/datasources/index.tsx
@@ -26,9 +26,14 @@ const DataSources = () => {
           {dataSources.map((ds) => (
             <div key={ds.id} className="rounded-xl border p-4 shadow">
               <h4 className="font-bold">{ds.name}</h4>
-              <Link to={`/data-sources/${ds.id}/edit`} className="mt-2 btn btn-sm btn-primary">
-                編集
-              </Link>
+              <div className="mt-2 space-x-2">
+                <Link to={`/data-sources/${ds.id}/edit`} className="btn btn-sm btn-primary">
+                  編集
+                </Link>
+                <Link to={`/data-sources/${ds.id}/upload`} className="btn btn-sm btn-secondary">
+                  アップロード
+                </Link>
+              </div>
             </div>
           ))}
           {dataSources.length === 0 && (

--- a/frontend/src/routes/datasources/new.stories.tsx
+++ b/frontend/src/routes/datasources/new.stories.tsx
@@ -1,0 +1,23 @@
+import { RouterProvider, createMemoryRouter } from "react-router-dom";
+import type { Meta, StoryObj } from "@storybook/react";
+import { within, expect } from "storybook/test";
+import NewDataSource from "./new";
+
+const router = createMemoryRouter([{ path: "/", element: <NewDataSource /> }]);
+
+const meta = {
+  component: NewDataSource,
+  render: () => <RouterProvider router={router} />,
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof NewDataSource>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("データソース新規作成")).toBeInTheDocument();
+  },
+};

--- a/frontend/src/routes/datasources/new.tsx
+++ b/frontend/src/routes/datasources/new.tsx
@@ -1,0 +1,51 @@
+import { FormEvent, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { createDataSource, NewDataSourceRequest } from "../../api/datasources";
+import DataSourceForm from "../../features/datasources/DataSourceForm";
+
+const NewDataSource = () => {
+  const navigate = useNavigate();
+  const [dataSource, setDataSource] = useState<Partial<NewDataSourceRequest>>({});
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!dataSource.name || !dataSource.symbol || !dataSource.timeframe || !dataSource.sourceType) {
+      return;
+    }
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      await createDataSource(dataSource as NewDataSourceRequest);
+      navigate("/data-sources");
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="p-6 space-y-6">
+      <header className="flex justify-between items-center">
+        <h2 className="text-2xl font-bold">データソース新規作成</h2>
+      </header>
+      <section>
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          {error && <p className="text-error">{error}</p>}
+          <DataSourceForm value={dataSource} onChange={setDataSource} />
+          <button
+            type="submit"
+            className="mt-4 bg-primary text-primary-content py-2 px-4 rounded"
+            disabled={isSubmitting}
+          >
+            作成
+          </button>
+        </form>
+      </section>
+    </div>
+  );
+};
+
+export default NewDataSource;

--- a/frontend/src/routes/datasources/upload.stories.tsx
+++ b/frontend/src/routes/datasources/upload.stories.tsx
@@ -1,0 +1,15 @@
+import { RouterProvider, createMemoryRouter } from "react-router-dom";
+import type { Meta, StoryObj } from "@storybook/react";
+import UploadTickFile from "./upload";
+
+const router = createMemoryRouter([{ path: "/", element: <UploadTickFile /> }]);
+
+const meta = {
+  component: UploadTickFile,
+  render: () => <RouterProvider router={router} />,
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof UploadTickFile>;
+
+export default meta;
+
+export const Default: StoryObj<typeof meta> = {};

--- a/frontend/src/routes/datasources/upload.tsx
+++ b/frontend/src/routes/datasources/upload.tsx
@@ -1,0 +1,45 @@
+import { FormEvent, useState } from "react";
+import { useNavigate, useParams } from "react-router-dom";
+import { uploadTickFile } from "../../api/ticks";
+
+const UploadTickFile = () => {
+  const { dataSourceId } = useParams<{ dataSourceId: string }>();
+  const navigate = useNavigate();
+  const [file, setFile] = useState<File | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+    if (!dataSourceId || !file) return;
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      await uploadTickFile(dataSourceId, file);
+      navigate("/data-sources");
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <div className="p-6 space-y-6">
+      <header>
+        <h2 className="text-2xl font-bold">チャンクアップロード</h2>
+      </header>
+      <section>
+        <form className="space-y-4" onSubmit={handleSubmit}>
+          {error && <p className="text-error">{error}</p>}
+          <input type="file" accept=".csv" onChange={(e) => setFile(e.target.files?.[0] ?? null)} />
+          <button type="submit" className="btn btn-primary" disabled={isSubmitting || !file}>
+            アップロード
+          </button>
+        </form>
+      </section>
+    </div>
+  );
+};
+
+export default UploadTickFile;

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -8,6 +8,7 @@ import Backtest from "./backtesting";
 import DataSources from "./datasources";
 import NewDataSource from "./datasources/new";
 import EditDataSource from "./datasources/edit";
+import UploadTickFile from "./datasources/upload";
 import Settings from "./settings";
 
 export const routes = [
@@ -24,6 +25,7 @@ export const routes = [
       { path: "data-sources", element: <DataSources /> },
       { path: "data-sources/new", element: <NewDataSource /> },
       { path: "data-sources/:dataSourceId/edit", element: <EditDataSource /> },
+      { path: "data-sources/:dataSourceId/upload", element: <UploadTickFile /> },
       { path: "settings", element: <Settings /> },
     ],
   },

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -6,6 +6,8 @@ import EditStrategy from "./strategies/edit";
 import NewStrategy from "./strategies/new";
 import Backtest from "./backtesting";
 import DataSources from "./datasources";
+import NewDataSource from "./datasources/new";
+import EditDataSource from "./datasources/edit";
 import Settings from "./settings";
 
 export const routes = [
@@ -20,6 +22,8 @@ export const routes = [
       { path: "strategies-new", element: <NewStrategy /> },
       { path: "backtest", element: <Backtest /> },
       { path: "data-sources", element: <DataSources /> },
+      { path: "data-sources/new", element: <NewDataSource /> },
+      { path: "data-sources/:dataSourceId/edit", element: <EditDataSource /> },
       { path: "settings", element: <Settings /> },
     ],
   },


### PR DESCRIPTION
## Summary
- implement front-end API for data sources
- add DataSource form component
- add pages for creating, editing, and listing data sources
- wire new pages into router
- test API helpers and components

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6861fa2e80088320aa13dbde52c440b7