### PR TITLE
Rename tick data functions

### DIFF
--- a/api/Stratrack.Api/Functions/DataChunkFunctions.cs
+++ b/api/Stratrack.Api/Functions/DataChunkFunctions.cs
@@ -20,26 +20,26 @@ using System.Text;
 
 namespace Stratrack.Api.Functions;
 
-public class TickDataFunctions(
+public class DataChunkFunctions(
     IQueryProcessor queryProcessor,
     IBlobStorage blobStorage,
     ICommandBus commandBus,
-    ILogger<TickDataFunctions> logger)
+    ILogger<DataChunkFunctions> logger)
 {
     private readonly IQueryProcessor _queryProcessor = queryProcessor;
     private readonly IBlobStorage _blobStorage = blobStorage;
     private readonly ICommandBus _commandBus = commandBus;
-    private readonly ILogger<TickDataFunctions> _logger = logger;
-    [Function("UploadTickChunk")]
-    [OpenApiOperation(operationId: "upload_tick_chunk", tags: ["TickData"])]
+    private readonly ILogger<DataChunkFunctions> _logger = logger;
+    [Function("UploadDataChunk")]
+    [OpenApiOperation(operationId: "upload_data_chunk", tags: ["DataChunks"])]
     [OpenApiSecurity("function_key", SecuritySchemeType.ApiKey, In = OpenApiSecurityLocationType.Header, Name = "x-functions-key")]
     [OpenApiParameter(name: "dataSourceId", In = ParameterLocation.Path, Required = true, Type = typeof(string))]
     [OpenApiRequestBody("application/json", typeof(TickChunkUploadRequest))]
     [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.Created, Description = "Created")]
     [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.NotFound, Description = "Not found")]
     [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.UnprocessableEntity, Description = "Unprocessable entity")]
-    public async Task<HttpResponseData> PostTickChunk(
-        [HttpTrigger(AuthorizationLevel.Function, "post", Route = "data-sources/{dataSourceId}/ticks")] HttpRequestData req,
+    public async Task<HttpResponseData> PostDataChunk(
+        [HttpTrigger(AuthorizationLevel.Function, "post", Route = "data-sources/{dataSourceId}/chunks")] HttpRequestData req,
         string dataSourceId,
         CancellationToken token)
     {
@@ -84,16 +84,16 @@ public class TickDataFunctions(
         return req.CreateResponse(HttpStatusCode.Created);
     }
 
-    [Function("UploadTickFile")]
-    [OpenApiOperation(operationId: "upload_tick_file", tags: ["TickData"])]
+    [Function("UploadDataFile")]
+    [OpenApiOperation(operationId: "upload_data_file", tags: ["DataChunks"])]
     [OpenApiSecurity("function_key", SecuritySchemeType.ApiKey, In = OpenApiSecurityLocationType.Header, Name = "x-functions-key")]
     [OpenApiParameter(name: "dataSourceId", In = ParameterLocation.Path, Required = true, Type = typeof(string))]
     [OpenApiRequestBody("application/json", typeof(TickFileUploadRequest))]
     [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.Created, Description = "Created")]
     [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.NotFound, Description = "Not found")]
     [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.UnprocessableEntity, Description = "Unprocessable entity")]
-    public async Task<HttpResponseData> PostTickFile(
-        [HttpTrigger(AuthorizationLevel.Function, "post", Route = "data-sources/{dataSourceId}/ticks/file")] HttpRequestData req,
+    public async Task<HttpResponseData> PostDataFile(
+        [HttpTrigger(AuthorizationLevel.Function, "post", Route = "data-sources/{dataSourceId}/file")] HttpRequestData req,
         string dataSourceId,
         CancellationToken token)
     {
@@ -150,16 +150,16 @@ public class TickDataFunctions(
         return req.CreateResponse(HttpStatusCode.Created);
     }
 
-    [Function("DeleteTickChunks")]
-    [OpenApiOperation(operationId: "delete_tick_chunks", tags: ["TickData"])]
+    [Function("DeleteDataChunks")]
+    [OpenApiOperation(operationId: "delete_data_chunks", tags: ["DataChunks"])]
     [OpenApiSecurity("function_key", SecuritySchemeType.ApiKey, In = OpenApiSecurityLocationType.Header, Name = "x-functions-key")]
     [OpenApiParameter(name: "dataSourceId", In = ParameterLocation.Path, Required = true, Type = typeof(string))]
     [OpenApiParameter(name: "startTime", In = ParameterLocation.Query, Required = false, Type = typeof(string))]
     [OpenApiParameter(name: "endTime", In = ParameterLocation.Query, Required = false, Type = typeof(string))]
     [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.NoContent, Description = "No content")]
     [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.NotFound, Description = "Not found")]
-    public async Task<HttpResponseData> DeleteTickChunks(
-        [HttpTrigger(AuthorizationLevel.Function, "delete", Route = "data-sources/{dataSourceId}/ticks")] HttpRequestData req,
+    public async Task<HttpResponseData> DeleteDataChunks(
+        [HttpTrigger(AuthorizationLevel.Function, "delete", Route = "data-sources/{dataSourceId}/chunks")] HttpRequestData req,
         string dataSourceId,
         CancellationToken token)
     {

--- a/frontend/src/api/data.ts
+++ b/frontend/src/api/data.ts
@@ -9,23 +9,23 @@ function toPlain<T>(value: T): T {
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "";
 const API_KEY = import.meta.env.VITE_API_KEY ?? "";
 
-type TickFileUploadRequest = {
+type DataFileUploadRequest = {
   fileName: string;
   base64Data: string;
 };
 
-export async function uploadTickFile(dataSourceId: string, file: File) {
+export async function uploadDataFile(dataSourceId: string, file: File) {
   const buf = await file.arrayBuffer();
   const base64Data = btoa(String.fromCharCode(...new Uint8Array(buf)));
-  const body: TickFileUploadRequest = { fileName: file.name, base64Data };
+  const body: DataFileUploadRequest = { fileName: file.name, base64Data };
 
-  const res = await fetch(`${API_BASE_URL}/api/data-sources/${dataSourceId}/ticks/file`, {
+  const res = await fetch(`${API_BASE_URL}/api/data-sources/${dataSourceId}/file`, {
     method: "POST",
     headers: { "Content-Type": "application/json", "x-functions-key": API_KEY },
     body: JSON.stringify(toPlain(body)),
   });
   if (!res.ok) {
-    throw new Error(`Failed to upload tick file: ${res.status}`);
+    throw new Error(`Failed to upload data file: ${res.status}`);
   }
   return res;
 }

--- a/frontend/src/routes/datasources/upload.stories.tsx
+++ b/frontend/src/routes/datasources/upload.stories.tsx
@@ -1,14 +1,14 @@
 import { RouterProvider, createMemoryRouter } from "react-router-dom";
 import type { Meta, StoryObj } from "@storybook/react";
-import UploadTickFile from "./upload";
+import UploadDataFile from "./upload";
 
-const router = createMemoryRouter([{ path: "/", element: <UploadTickFile /> }]);
+const router = createMemoryRouter([{ path: "/", element: <UploadDataFile /> }]);
 
 const meta = {
-  component: UploadTickFile,
+  component: UploadDataFile,
   render: () => <RouterProvider router={router} />,
   parameters: { layout: "fullscreen" },
-} satisfies Meta<typeof UploadTickFile>;
+} satisfies Meta<typeof UploadDataFile>;
 
 export default meta;
 

--- a/frontend/src/routes/datasources/upload.tsx
+++ b/frontend/src/routes/datasources/upload.tsx
@@ -1,8 +1,8 @@
 import { FormEvent, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
-import { uploadTickFile } from "../../api/ticks";
+import { uploadDataFile } from "../../api/data";
 
-const UploadTickFile = () => {
+const UploadDataFile = () => {
   const { dataSourceId } = useParams<{ dataSourceId: string }>();
   const navigate = useNavigate();
   const [file, setFile] = useState<File | null>(null);
@@ -15,7 +15,7 @@ const UploadTickFile = () => {
     setIsSubmitting(true);
     setError(null);
     try {
-      await uploadTickFile(dataSourceId, file);
+      await uploadDataFile(dataSourceId, file);
       navigate("/data-sources");
     } catch (err) {
       setError((err as Error).message);
@@ -42,4 +42,4 @@ const UploadTickFile = () => {
   );
 };
 
-export default UploadTickFile;
+export default UploadDataFile;

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -8,7 +8,7 @@ import Backtest from "./backtesting";
 import DataSources from "./datasources";
 import NewDataSource from "./datasources/new";
 import EditDataSource from "./datasources/edit";
-import UploadTickFile from "./datasources/upload";
+import UploadDataFile from "./datasources/upload";
 import Settings from "./settings";
 
 export const routes = [
@@ -25,7 +25,7 @@ export const routes = [
       { path: "data-sources", element: <DataSources /> },
       { path: "data-sources/new", element: <NewDataSource /> },
       { path: "data-sources/:dataSourceId/edit", element: <EditDataSource /> },
-      { path: "data-sources/:dataSourceId/upload", element: <UploadTickFile /> },
+      { path: "data-sources/:dataSourceId/upload", element: <UploadDataFile /> },
       { path: "settings", element: <Settings /> },
     ],
   },


### PR DESCRIPTION
## Summary
- rename TickDataFunctions -> DataChunkFunctions
- adjust file upload to `/file` under datasource root
- update tests for renamed functions
- rename frontend tick API and related components

## Testing
- `dotnet test api/stratrack-backend.sln -c Release`
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6863df8ebba88320b2051ce17a0c9bb1