### PR TITLE
Persist blobs in database

### DIFF
--- a/api/Stratrack.Api.Tests/DataStreamFunctionsTests.cs
+++ b/api/Stratrack.Api.Tests/DataStreamFunctionsTests.cs
@@ -1,0 +1,79 @@
+using EventFlow.EntityFramework;
+using Microsoft.Extensions.DependencyInjection;
+using Stratrack.Api.Domain;
+using Stratrack.Api.Functions;
+using Stratrack.Api.Infrastructure;
+using Stratrack.Api.Models;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using WorkerHttpFake;
+
+namespace Stratrack.Api.Tests;
+
+[TestClass]
+public class DataStreamFunctionsTests
+{
+    private static ServiceProvider CreateProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddStratrack<StratrackDbContextProvider>();
+        services.AddSingleton<DataSourceFunctions>();
+        services.AddSingleton<DataChunkFunctions>();
+        services.AddSingleton<DataStreamFunctions>();
+        var provider = services.BuildServiceProvider();
+        using var ctx = provider.GetRequiredService<IDbContextProvider<StratrackDbContext>>().CreateContext();
+        ctx.Database.EnsureDeleted();
+        return provider;
+    }
+
+    private static async Task<string> CreateDataSourceAsync(ServiceProvider provider)
+    {
+        var func = provider.GetRequiredService<DataSourceFunctions>();
+        var req = new HttpRequestDataBuilder()
+            .WithUrl("http://localhost/api/data-sources")
+            .WithMethod(HttpMethod.Post)
+            .WithBody(JsonSerializer.Serialize(new DataSourceCreateRequest
+            {
+                Name = "ds",
+                Symbol = "EURUSD",
+                Timeframe = "tick",
+                SourceType = "dukascopy"
+            }))
+            .Build();
+        var res = await func.PostDataSource(req, CancellationToken.None);
+        var detail = await res.ReadAsJsonAsync<DataSourceDetail>();
+        return detail.Id.ToString();
+    }
+
+    [TestMethod]
+    public async Task GetDataStream_ReturnsChunkData()
+    {
+        using var provider = CreateProvider();
+        var dsId = await CreateDataSourceAsync(provider);
+        var chunkFunc = provider.GetRequiredService<DataChunkFunctions>();
+        var data = Convert.ToBase64String(Encoding.UTF8.GetBytes("time,bid,ask\n"));
+        var uploadReq = new HttpRequestDataBuilder()
+            .WithUrl($"http://localhost/api/data-sources/{dsId}/chunks")
+            .WithMethod(HttpMethod.Post)
+            .WithBody(JsonSerializer.Serialize(new TickChunkUploadRequest
+            {
+                StartTime = new DateTimeOffset(2024,1,1,0,0,0,TimeSpan.Zero),
+                EndTime = new DateTimeOffset(2024,1,1,1,0,0,TimeSpan.Zero),
+                Base64Data = data
+            }))
+            .Build();
+        await chunkFunc.PostDataChunk(uploadReq, dsId, CancellationToken.None);
+
+        var streamFunc = provider.GetRequiredService<DataStreamFunctions>();
+        var req = new HttpRequestDataBuilder()
+            .WithUrl($"http://localhost/api/data-sources/{dsId}/stream?startTime=2024-01-01T00:00:00Z&endTime=2024-01-01T01:00:00Z")
+            .WithMethod(HttpMethod.Get)
+            .Build();
+        var res = await streamFunc.GetDataStream(req, dsId, CancellationToken.None);
+        Assert.AreEqual(HttpStatusCode.OK, res.StatusCode);
+        var body = await res.ReadAsStringAsync();
+        Assert.AreEqual("time,bid,ask\n", body);
+    }
+}

--- a/api/Stratrack.Api/Domain/Blobs/BlobData.cs
+++ b/api/Stratrack.Api/Domain/Blobs/BlobData.cs
@@ -1,0 +1,12 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Stratrack.Api.Domain.Blobs;
+
+public class BlobData
+{
+    [Key]
+    public Guid Id { get; set; }
+    public string FileName { get; set; } = "";
+    public string ContentType { get; set; } = "";
+    public byte[] Data { get; set; } = Array.Empty<byte>();
+}

--- a/api/Stratrack.Api/Domain/Blobs/IBlobStorage.cs
+++ b/api/Stratrack.Api/Domain/Blobs/IBlobStorage.cs
@@ -3,5 +3,6 @@ namespace Stratrack.Api.Domain.Blobs;
 public interface IBlobStorage
 {
     Task<Guid> SaveAsync(string fileName, string contentType, byte[] data, CancellationToken token);
+    Task<byte[]> GetAsync(Guid blobId, CancellationToken token);
     Task DeleteAsync(Guid blobId, CancellationToken token);
 }

--- a/api/Stratrack.Api/Domain/StratrackDbContext.cs
+++ b/api/Stratrack.Api/Domain/StratrackDbContext.cs
@@ -3,6 +3,7 @@ using Microsoft.EntityFrameworkCore;
 using Stratrack.Api.Domain.DataSources;
 using Stratrack.Api.Domain.Strategies;
 using Stratrack.Api.Domain.Dukascopy;
+using Stratrack.Api.Domain.Blobs;
 
 namespace Stratrack.Api.Domain;
 
@@ -19,6 +20,7 @@ public class StratrackDbContext : DbContext
     public DbSet<DataSourceReadModel> DataSources { get; set; }
     public DbSet<DukascopyJobReadModel> DukascopyJobs { get; set; }
     public DbSet<DataChunkReadModel> DataChunks { get; set; }
+    public DbSet<BlobData> Blobs { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -39,6 +41,10 @@ public class StratrackDbContext : DbContext
         modelBuilder.Entity<DataChunkReadModel>(entity =>
         {
             entity.HasKey(m => m.Id);
+        });
+        modelBuilder.Entity<BlobData>(entity =>
+        {
+            entity.HasKey(b => b.Id);
         });
     }
 }

--- a/api/Stratrack.Api/Functions/DataStreamFunctions.cs
+++ b/api/Stratrack.Api/Functions/DataStreamFunctions.cs
@@ -1,0 +1,83 @@
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
+using Microsoft.OpenApi.Models;
+using Microsoft.Extensions.Logging;
+using Stratrack.Api.Domain.Blobs;
+using Stratrack.Api.Domain.DataSources;
+using Stratrack.Api.Domain.DataSources.Queries;
+using EventFlow.Queries;
+using System.Net;
+using System.Linq;
+using System;
+
+namespace Stratrack.Api.Functions;
+
+public class DataStreamFunctions(
+    IQueryProcessor queryProcessor,
+    IBlobStorage blobStorage,
+    ILogger<DataStreamFunctions> logger)
+{
+    private readonly IQueryProcessor _queryProcessor = queryProcessor;
+    private readonly IBlobStorage _blobStorage = blobStorage;
+    private readonly ILogger<DataStreamFunctions> _logger = logger;
+
+    [Function("GetDataStream")]
+    [OpenApiOperation(operationId: "get_data_stream", tags: ["DataSources"])]
+    [OpenApiSecurity("function_key", SecuritySchemeType.ApiKey, In = OpenApiSecurityLocationType.Header, Name = "x-functions-key")]
+    [OpenApiParameter(name: "dataSourceId", In = ParameterLocation.Path, Required = true, Type = typeof(string))]
+    [OpenApiParameter(name: "startTime", In = ParameterLocation.Query, Required = true, Type = typeof(string))]
+    [OpenApiParameter(name: "endTime", In = ParameterLocation.Query, Required = true, Type = typeof(string))]
+    [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.OK, Description = "Ok")]
+    [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.NotFound, Description = "Not found")]
+    [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.UnprocessableEntity, Description = "Unprocessable entity")]
+    public async Task<HttpResponseData> GetDataStream(
+        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "data-sources/{dataSourceId}/stream")] HttpRequestData req,
+        string dataSourceId,
+        CancellationToken token)
+    {
+        var query = System.Web.HttpUtility.ParseQueryString(req.Url.Query);
+        var startStr = query.Get("startTime");
+        var endStr = query.Get("endTime");
+        if (startStr == null || endStr == null)
+        {
+            return req.CreateResponse(HttpStatusCode.UnprocessableEntity);
+        }
+
+        DateTimeOffset start;
+        DateTimeOffset end;
+        try
+        {
+            start = DateTimeOffset.Parse(startStr);
+            end = DateTimeOffset.Parse(endStr);
+        }
+        catch
+        {
+            return req.CreateResponse(HttpStatusCode.UnprocessableEntity);
+        }
+
+        var dsId = Guid.Parse(dataSourceId);
+        var sources = await _queryProcessor.ProcessAsync(new DataSourceReadModelSearchQuery(), token).ConfigureAwait(false);
+        var dataSource = sources.FirstOrDefault(d => d.DataSourceId == dsId);
+        if (dataSource == null)
+        {
+            return req.CreateResponse(HttpStatusCode.NotFound);
+        }
+
+        var chunks = await _queryProcessor.ProcessAsync(new DataChunkReadModelSearchQuery(dsId), token).ConfigureAwait(false);
+        var target = chunks
+            .Where(c => c.StartTime < end && c.EndTime > start)
+            .OrderBy(c => c.StartTime)
+            .ToList();
+
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        response.Headers.Add("Content-Type", "text/plain");
+        foreach (var chunk in target)
+        {
+            var data = await _blobStorage.GetAsync(chunk.BlobId, token).ConfigureAwait(false);
+            await response.Body.WriteAsync(data, token).ConfigureAwait(false);
+        }
+        return response;
+    }
+}

--- a/api/Stratrack.Api/Infrastructure/DatabaseBlobStorage.cs
+++ b/api/Stratrack.Api/Infrastructure/DatabaseBlobStorage.cs
@@ -1,21 +1,44 @@
+using EventFlow.EntityFramework;
+using Microsoft.EntityFrameworkCore;
+using Stratrack.Api.Domain;
 using Stratrack.Api.Domain.Blobs;
-using System.Collections.Concurrent;
 
 namespace Stratrack.Api.Infrastructure;
 
-public class DatabaseBlobStorage : IBlobStorage
+public class DatabaseBlobStorage(IDbContextProvider<StratrackDbContext> dbContextProvider) : IBlobStorage
 {
-    private readonly ConcurrentDictionary<Guid, byte[]> _store = new();
-    public Task<Guid> SaveAsync(string fileName, string contentType, byte[] data, CancellationToken token)
+    private readonly IDbContextProvider<StratrackDbContext> _provider = dbContextProvider;
+
+    public async Task<Guid> SaveAsync(string fileName, string contentType, byte[] data, CancellationToken token)
     {
         var id = Guid.NewGuid();
-        _store[id] = data;
-        return Task.FromResult(id);
+        using var context = _provider.CreateContext();
+        context.Blobs.Add(new BlobData
+        {
+            Id = id,
+            FileName = fileName,
+            ContentType = contentType,
+            Data = data
+        });
+        await context.SaveChangesAsync(token).ConfigureAwait(false);
+        return id;
     }
 
-    public Task DeleteAsync(Guid blobId, CancellationToken token)
+    public async Task<byte[]> GetAsync(Guid blobId, CancellationToken token)
     {
-        _store.TryRemove(blobId, out _);
-        return Task.CompletedTask;
+        using var context = _provider.CreateContext();
+        var blob = await context.Blobs.FirstOrDefaultAsync(b => b.Id == blobId, token).ConfigureAwait(false);
+        return blob?.Data ?? Array.Empty<byte>();
+    }
+
+    public async Task DeleteAsync(Guid blobId, CancellationToken token)
+    {
+        using var context = _provider.CreateContext();
+        var blob = await context.Blobs.FirstOrDefaultAsync(b => b.Id == blobId, token).ConfigureAwait(false);
+        if (blob != null)
+        {
+            context.Blobs.Remove(blob);
+            await context.SaveChangesAsync(token).ConfigureAwait(false);
+        }
     }
 }

--- a/frontend/src/api/data.ts
+++ b/frontend/src/api/data.ts
@@ -29,3 +29,21 @@ export async function uploadDataFile(dataSourceId: string, file: File) {
   }
   return res;
 }
+
+export async function getDataStream(
+  dataSourceId: string,
+  startTime: string,
+  endTime: string
+): Promise<string> {
+  const params = new URLSearchParams({ startTime, endTime });
+  const res = await fetch(
+    `${API_BASE_URL}/api/data-sources/${dataSourceId}/stream?${params.toString()}`,
+    {
+      headers: { "x-functions-key": API_KEY },
+    }
+  );
+  if (!res.ok) {
+    throw new Error(`Failed to fetch data stream: ${res.status}`);
+  }
+  return res.text();
+}

--- a/frontend/src/components/LineChart.stories.tsx
+++ b/frontend/src/components/LineChart.stories.tsx
@@ -1,0 +1,22 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import LineChart from "./LineChart";
+
+const meta: Meta<typeof LineChart> = {
+  component: LineChart,
+};
+export default meta;
+
+type Story = StoryObj<typeof LineChart>;
+
+export const Default: Story = {
+  args: {
+    width: 300,
+    height: 150,
+    data: [
+      { x: 0, y: 1 },
+      { x: 1, y: 2 },
+      { x: 2, y: 1.5 },
+      { x: 3, y: 3 },
+    ],
+  },
+};

--- a/frontend/src/components/LineChart.tsx
+++ b/frontend/src/components/LineChart.tsx
@@ -1,0 +1,34 @@
+export type LinePoint = { x: number; y: number };
+
+export type LineChartProps = {
+  width?: number;
+  height?: number;
+  data: LinePoint[];
+};
+
+const LineChart = ({ width = 600, height = 300, data }: LineChartProps) => {
+  if (data.length === 0) {
+    return <svg width={width} height={height}></svg>;
+  }
+
+  const minX = Math.min(...data.map((d) => d.x));
+  const maxX = Math.max(...data.map((d) => d.x));
+  const minY = Math.min(...data.map((d) => d.y));
+  const maxY = Math.max(...data.map((d) => d.y));
+
+  const points = data
+    .map((d) => {
+      const x = ((d.x - minX) / (maxX - minX)) * width;
+      const y = height - ((d.y - minY) / (maxY - minY)) * height;
+      return `${x},${y}`;
+    })
+    .join(" ");
+
+  return (
+    <svg width={width} height={height} className="border rounded">
+      <polyline fill="none" stroke="currentColor" strokeWidth="1" points={points} />
+    </svg>
+  );
+};
+
+export default LineChart;

--- a/frontend/src/features/datasources/DataSourceForm.stories.tsx
+++ b/frontend/src/features/datasources/DataSourceForm.stories.tsx
@@ -16,6 +16,8 @@ export const Default: Story = {
   play: async ({ canvasElement, args }) => {
     const canvas = within(canvasElement);
     await userEvent.type(canvas.getByLabelText("名称"), "test");
+    await userEvent.selectOptions(canvas.getByLabelText("時間足"), "tick");
+    await userEvent.selectOptions(canvas.getByLabelText("ソース種別"), "dukascopy");
     await expect(args.onChange).toHaveBeenCalled();
   },
 };

--- a/frontend/src/features/datasources/DataSourceForm.tsx
+++ b/frontend/src/features/datasources/DataSourceForm.tsx
@@ -1,5 +1,6 @@
 import { useCallback } from "react";
 import Input from "../../components/Input";
+import Select from "../../components/Select";
 import Textarea from "../../components/Textarea";
 import { useLocalValue } from "../../hooks/useLocalValue";
 
@@ -16,6 +17,18 @@ export type DataSourceFormProps = {
   onChange?: (value: DataSourceFormValue) => void;
   hideSourceFields?: boolean;
 };
+
+const TIMEFRAME_OPTIONS = [
+  { value: "tick", label: "ティック" },
+  { value: "5m", label: "5分足" },
+];
+
+const SOURCE_TYPE_OPTIONS = [
+  { value: "dukascopy", label: "Dukascopy" },
+  { value: "mt4", label: "MT4" },
+  { value: "mt5", label: "MT5" },
+  { value: "custom_upload", label: "カスタムアップロード" },
+];
 
 function DataSourceForm({ value, onChange, hideSourceFields = false }: DataSourceFormProps) {
   const [localValue, setLocalValue] = useLocalValue<DataSourceFormValue>({}, value, onChange);
@@ -59,18 +72,22 @@ function DataSourceForm({ value, onChange, hideSourceFields = false }: DataSourc
             required
             fullWidth
           />
-          <Input
+          <Select
             label="時間足"
             value={localValue.timeframe || ""}
             onChange={handleTimeframeChange}
+            options={TIMEFRAME_OPTIONS}
             required
+            allowEmpty={false}
             fullWidth
           />
-          <Input
+          <Select
             label="ソース種別"
             value={localValue.sourceType || ""}
             onChange={handleSourceTypeChange}
+            options={SOURCE_TYPE_OPTIONS}
             required
+            allowEmpty={false}
             fullWidth
           />
         </>

--- a/frontend/src/routes/datasources/chart.tsx
+++ b/frontend/src/routes/datasources/chart.tsx
@@ -1,0 +1,42 @@
+import { useState } from "react";
+import { useParams } from "react-router-dom";
+import { getDataStream } from "../../api/data";
+import LineChart, { LinePoint } from "../../components/LineChart";
+import TimeRangePicker, { TimeRange } from "../../components/TimeRangePicker";
+import Button from "../../components/Button";
+
+const DataSourceChart = () => {
+  const { dataSourceId } = useParams<{ dataSourceId: string }>();
+  const [range, setRange] = useState<TimeRange>({});
+  const [data, setData] = useState<LinePoint[]>([]);
+  const [error, setError] = useState<string | null>(null);
+  const handleLoad = async () => {
+    if (!dataSourceId || !range.from || !range.to) return;
+    try {
+      const csv = await getDataStream(dataSourceId, range.from, range.to);
+      const lines = csv.split(/\r?\n/).filter((l) => l && !l.startsWith("time"));
+      const points: LinePoint[] = lines.map((l) => {
+        const [t, bid] = l.split(",");
+        return { x: Date.parse(t), y: parseFloat(bid) };
+      });
+      setData(points);
+      setError(null);
+    } catch (e) {
+      setError((e as Error).message);
+    }
+  };
+
+  return (
+    <div className="p-6 space-y-4">
+      <h2 className="text-2xl font-bold">チャート表示</h2>
+      <div className="space-y-2">
+        <TimeRangePicker label="期間" value={range} onChange={setRange} fullWidth />
+        <Button onClick={handleLoad}>表示</Button>
+        {error && <p className="text-error">{error}</p>}
+      </div>
+      <LineChart data={data} />
+    </div>
+  );
+};
+
+export default DataSourceChart;

--- a/frontend/src/routes/datasources/index.tsx
+++ b/frontend/src/routes/datasources/index.tsx
@@ -33,6 +33,9 @@ const DataSources = () => {
                 <Link to={`/data-sources/${ds.id}/upload`} className="btn btn-sm btn-secondary">
                   アップロード
                 </Link>
+                <Link to={`/data-sources/${ds.id}/chart`} className="btn btn-sm btn-outline">
+                  チャート
+                </Link>
               </div>
             </div>
           ))}

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -9,6 +9,7 @@ import DataSources from "./datasources";
 import NewDataSource from "./datasources/new";
 import EditDataSource from "./datasources/edit";
 import UploadDataFile from "./datasources/upload";
+import DataSourceChart from "./datasources/chart";
 import Settings from "./settings";
 
 export const routes = [
@@ -26,6 +27,7 @@ export const routes = [
       { path: "data-sources/new", element: <NewDataSource /> },
       { path: "data-sources/:dataSourceId/edit", element: <EditDataSource /> },
       { path: "data-sources/:dataSourceId/upload", element: <UploadDataFile /> },
+      { path: "data-sources/:dataSourceId/chart", element: <DataSourceChart /> },
       { path: "settings", element: <Settings /> },
     ],
   },


### PR DESCRIPTION
## Summary
- add `BlobData` entity to persist blob bytes
- extend `StratrackDbContext` with `Blobs` DbSet
- implement `DatabaseBlobStorage` with EF Core for durable storage
- implement `GetDataStream` streaming API and tests
- add chart viewer in frontend
- use select inputs for timeframe and source type when creating data sources

## Testing
- `dotnet test api/stratrack-backend.sln -c Release`
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6863e2b650d0832096b64d6bc6306f9c