### PR TITLE
Refactor data source fields and CSV handling

### DIFF
--- a/api/Stratrack.Api.Tests/DataSourceFunctionsTests.cs
+++ b/api/Stratrack.Api.Tests/DataSourceFunctionsTests.cs
@@ -81,7 +81,7 @@ public class DataSourceFunctionsTests
                     Name = "DataSource 1",
                     Symbol = "EURUSD",
                     Timeframe = "H1",
-                    SourceType = "ducascopy",
+                    Fields = new List<string>{"bid","ask"},
                     Description = "Description",
                 }
             ))
@@ -96,7 +96,7 @@ public class DataSourceFunctionsTests
         Assert.AreEqual("DataSource 1", obj.Name);
         Assert.AreEqual("EURUSD", obj.Symbol);
         Assert.AreEqual("H1", obj.Timeframe);
-        Assert.AreEqual("ducascopy", obj.SourceType);
+        CollectionAssert.AreEqual(new List<string>{"bid","ask"}, obj.Fields);
         Assert.AreEqual("Description", obj.Description);
     }
 
@@ -130,7 +130,7 @@ public class DataSourceFunctionsTests
             Name = "DataSource 1",
             Symbol = "EURUSD",
             Timeframe = "H1",
-            SourceType = "dukascopy",
+            Fields = new List<string>{"bid","ask"},
             Description = "Description",
         }).ConfigureAwait(false);
 
@@ -160,7 +160,7 @@ public class DataSourceFunctionsTests
             Name = "DataSource 1",
             Symbol = "EURUSD",
             Timeframe = "H1",
-            SourceType = "dukascopy",
+            Fields = new List<string>{"bid","ask"},
             Description = "Description",
         }).ConfigureAwait(false);
 
@@ -202,7 +202,7 @@ public class DataSourceFunctionsTests
                 Name = "x",
                 Symbol = "EURUSD",
                 Timeframe = "H1",
-                SourceType = "dukascopy"
+                Fields = new List<string>{"bid","ask"}
             }))
             .Build();
 
@@ -222,7 +222,7 @@ public class DataSourceFunctionsTests
             Name = "name",
             Symbol = "EURUSD",
             Timeframe = "H1",
-            SourceType = "dukascopy",
+            Fields = new List<string>{"bid","ask"},
         }).ConfigureAwait(false);
 
         var request = new HttpRequestDataBuilder()

--- a/api/Stratrack.Api.Tests/DataStreamFunctionsTests.cs
+++ b/api/Stratrack.Api.Tests/DataStreamFunctionsTests.cs
@@ -39,7 +39,7 @@ public class DataStreamFunctionsTests
                 Name = "ds",
                 Symbol = "EURUSD",
                 Timeframe = "tick",
-                SourceType = "dukascopy"
+                Fields = new List<string>{"bid","ask"}
             }))
             .Build();
         var res = await func.PostDataSource(req, CancellationToken.None);

--- a/api/Stratrack.Api/Domain/DataSources/Commands/DataSourceCreateCommand.cs
+++ b/api/Stratrack.Api/Domain/DataSources/Commands/DataSourceCreateCommand.cs
@@ -7,6 +7,6 @@ public class DataSourceCreateCommand(DataSourceId aggregateId) : Command<DataSou
     public string Name { get; set; } = "";
     public string Symbol { get; set; } = "";
     public string Timeframe { get; set; } = "";
-    public string SourceType { get; set; } = "";
+    public List<string> Fields { get; set; } = [];
     public string? Description { get; set; }
 }

--- a/api/Stratrack.Api/Domain/DataSources/Commands/DataSourceCreateCommandHandler.cs
+++ b/api/Stratrack.Api/Domain/DataSources/Commands/DataSourceCreateCommandHandler.cs
@@ -6,7 +6,7 @@ public class DataSourceCreateCommandHandler : CommandHandler<DataSourceAggregate
 {
     public override Task ExecuteAsync(DataSourceAggregate aggregate, DataSourceCreateCommand command, CancellationToken cancellationToken)
     {
-        aggregate.Create(command.Name, command.Symbol, command.Timeframe, command.SourceType, command.Description);
+        aggregate.Create(command.Name, command.Symbol, command.Timeframe, command.Fields, command.Description);
         return Task.CompletedTask;
     }
 }

--- a/api/Stratrack.Api/Domain/DataSources/DataSourceAggregate.cs
+++ b/api/Stratrack.Api/Domain/DataSources/DataSourceAggregate.cs
@@ -15,12 +15,9 @@ public class DataSourceAggregate(DataSourceId id) : AggregateRoot<DataSourceAggr
     public string? Description { get; private set; }
     public string Symbol { get; private set; } = "";
     public string Timeframe { get; private set; } = "";
-    /// <summary>
-    /// ducascopy, mt4
-    /// </summary>
-    public string SourceType { get; private set; } = "";
+    public List<string> Fields { get; private set; } = [];
 
-    public void Create(string name, string symbol, string timeframe, string sourceType, string? description)
+    public void Create(string name, string symbol, string timeframe, IEnumerable<string> fields, string? description)
     {
         if (isDeleted == true)
         {
@@ -29,7 +26,7 @@ public class DataSourceAggregate(DataSourceId id) : AggregateRoot<DataSourceAggr
         if (DataSourceName == name
             && Symbol == symbol
             && Timeframe == timeframe
-            && SourceType == sourceType
+            && Fields.SequenceEqual(fields)
             && Description == description)
         {
             return;
@@ -37,7 +34,7 @@ public class DataSourceAggregate(DataSourceId id) : AggregateRoot<DataSourceAggr
 
         // Assuming that the symbol, timeframe, and sourceType are not stored in this aggregate.
         // If they are needed, they should be added as properties and handled accordingly.
-        Emit(new DataSourceCreatedEvent(Id, name, symbol, timeframe, sourceType, description));
+        Emit(new DataSourceCreatedEvent(Id, name, symbol, timeframe, fields.ToList(), description));
     }
 
     public void Update(string name, string? description)
@@ -63,7 +60,7 @@ public class DataSourceAggregate(DataSourceId id) : AggregateRoot<DataSourceAggr
         DataSourceName = aggregateEvent.Name;
         Symbol = aggregateEvent.Symbol;
         Timeframe = aggregateEvent.Timeframe;
-        SourceType = aggregateEvent.SourceType;
+        Fields = aggregateEvent.Fields.ToList();
         Description = aggregateEvent.Description;
     }
 

--- a/api/Stratrack.Api/Domain/DataSources/DataSourceReadModel.cs
+++ b/api/Stratrack.Api/Domain/DataSources/DataSourceReadModel.cs
@@ -17,7 +17,7 @@ public class DataSourceReadModel : IReadModel,
     public string Name { get; set; } = "";
     public string Symbol { get; set; } = "";
     public string Timeframe { get; set; } = "";
-    public string SourceType { get; set; } = "";
+    public string Fields { get; set; } = "";
     public string? Description { get; set; }
     public DateTimeOffset CreatedAt { get; private set; }
     public DateTimeOffset UpdatedAt { get; private set; }
@@ -30,7 +30,7 @@ public class DataSourceReadModel : IReadModel,
         Name = dataSourceCreatedEvent.Name;
         Symbol = dataSourceCreatedEvent.Symbol;
         Timeframe = dataSourceCreatedEvent.Timeframe;
-        SourceType = dataSourceCreatedEvent.SourceType;
+        Fields = string.Join(',', dataSourceCreatedEvent.Fields);
         Description = dataSourceCreatedEvent.Description;
         CreatedAt = domainEvent.Timestamp;
         UpdatedAt = domainEvent.Timestamp;

--- a/api/Stratrack.Api/Domain/DataSources/Events/DataSourceCreatedEvent.cs
+++ b/api/Stratrack.Api/Domain/DataSources/Events/DataSourceCreatedEvent.cs
@@ -4,13 +4,13 @@ using EventFlow.EventStores;
 namespace Stratrack.Api.Domain.DataSources.Events
 {
     [EventVersion("DataSourceCreated", 1)]
-    public class DataSourceCreatedEvent(DataSourceId id, string name, string symbol, string timeframe, string sourceType, string? description) : AggregateEvent<DataSourceAggregate, DataSourceId>
+    public class DataSourceCreatedEvent(DataSourceId id, string name, string symbol, string timeframe, IReadOnlyCollection<string> fields, string? description) : AggregateEvent<DataSourceAggregate, DataSourceId>
     {
         public DataSourceId Id { get; } = id;
         public string Name { get; } = name;
         public string Symbol { get; internal set; } = symbol;
         public string Timeframe { get; internal set; } = timeframe;
-        public string SourceType { get; internal set; } = sourceType;
+        public IReadOnlyCollection<string> Fields { get; internal set; } = fields;
         public string? Description { get; } = description;
     }
 }

--- a/api/Stratrack.Api/Domain/Dukascopy/DukascopyFetchService.cs
+++ b/api/Stratrack.Api/Domain/Dukascopy/DukascopyFetchService.cs
@@ -31,7 +31,11 @@ public class DukascopyFetchService(
         try
         {
             var sources = await _queryProcessor.ProcessAsync(new DataSourceReadModelSearchQuery(), token).ConfigureAwait(false);
-            foreach (var ds in sources.Where(d => d.SourceType == "dukascopy" && d.Timeframe == "tick" && d.Symbol == symbol))
+            foreach (var ds in sources.Where(d =>
+                d.Timeframe == "tick" &&
+                d.Symbol == symbol &&
+                (d.Fields?.Split(',').Contains("bid") ?? false) &&
+                (d.Fields?.Split(',').Contains("ask") ?? false)))
             {
                 await ProcessSourceAsync(ds, startTime, token).ConfigureAwait(false);
             }

--- a/api/Stratrack.Api/Domain/ServiceCollectionExtension.cs
+++ b/api/Stratrack.Api/Domain/ServiceCollectionExtension.cs
@@ -90,6 +90,7 @@ public static class ServiceCollectionExtension
                 s.AddSingleton<DataChunkReadModelLocator>();
                 s.AddSingleton<IDukascopyClient, DukascopyClient>();
                 s.AddSingleton<DukascopyFetchService>();
+                s.AddSingleton<CsvChunkService>();
             });
         });
     }

--- a/api/Stratrack.Api/Functions/DataSourceFunctions.cs
+++ b/api/Stratrack.Api/Functions/DataSourceFunctions.cs
@@ -68,7 +68,7 @@ public class DataSourceFunctions(ICommandBus commandBus, IQueryProcessor queryPr
                 Name = body.Name,
                 Symbol = body.Symbol,
                 Timeframe = body.Timeframe,
-                SourceType = body.SourceType,
+                Fields = body.Fields ?? new List<string>(),
                 Description = body.Description,
             }, token).ConfigureAwait(false);
         }
@@ -205,7 +205,7 @@ public class DataSourceFunctions(ICommandBus commandBus, IQueryProcessor queryPr
             Name = result.Name,
             Symbol = result.Symbol,
             Timeframe = result.Timeframe,
-            SourceType = result.SourceType,
+            Fields = result.Fields.Split(',', StringSplitOptions.RemoveEmptyEntries).ToList(),
             Description = result.Description,
             CreatedAt = result.CreatedAt,
             UpdatedAt = result.UpdatedAt,

--- a/api/Stratrack.Api/Infrastructure/CsvChunkService.cs
+++ b/api/Stratrack.Api/Infrastructure/CsvChunkService.cs
@@ -1,0 +1,85 @@
+using EventFlow;
+using EventFlow.Queries;
+using Microsoft.Extensions.Logging;
+using Stratrack.Api.Domain.Blobs;
+using Stratrack.Api.Domain.DataSources.Commands;
+using Stratrack.Api.Domain.DataSources.Queries;
+using Stratrack.Api.Domain.DataSources;
+using System.Text;
+
+namespace Stratrack.Api.Infrastructure;
+
+public class CsvChunkService(
+    IQueryProcessor queryProcessor,
+    IBlobStorage blobStorage,
+    ICommandBus commandBus,
+    ILogger<CsvChunkService> logger)
+{
+    private readonly IQueryProcessor _queryProcessor = queryProcessor;
+    private readonly IBlobStorage _blobStorage = blobStorage;
+    private readonly ICommandBus _commandBus = commandBus;
+    private readonly ILogger<CsvChunkService> _logger = logger;
+
+    public async Task<bool> ProcessAsync(DataSourceReadModel dataSource, string base64Data, CancellationToken token)
+    {
+        try
+        {
+            var csv = Encoding.UTF8.GetString(Convert.FromBase64String(base64Data));
+            var lines = csv.Split('\n', StringSplitOptions.RemoveEmptyEntries);
+            if (lines.Length <= 1)
+            {
+                return false;
+            }
+
+            var headerParts = lines[0].Split(',').Select(p => p.Trim().ToLower()).ToArray();
+            var required = new[] { "time" }
+                .Concat((dataSource.Fields ?? string.Empty).Split(',', StringSplitOptions.RemoveEmptyEntries).Select(p => p.Trim().ToLower()))
+                .ToArray();
+            var indices = new Dictionary<string, int>();
+            foreach (var field in required)
+            {
+                var idx = Array.IndexOf(headerParts, field);
+                if (idx < 0)
+                {
+                    return false;
+                }
+                indices[field] = idx;
+            }
+
+            var entries = lines.Skip(1)
+                .Select(l => l.Split(','))
+                .Select(p => new
+                {
+                    Time = DateTimeOffset.Parse(p[indices["time"]]),
+                    Line = string.Join(',', required.Skip(1).Select(f => p[indices[f]]))
+                })
+                .GroupBy(e => new DateTimeOffset(e.Time.Year, e.Time.Month, e.Time.Day, e.Time.Hour, 0, 0, e.Time.Offset));
+
+            var existing = await _queryProcessor.ProcessAsync(new DataChunkReadModelSearchQuery(dataSource.DataSourceId), token).ConfigureAwait(false);
+            var header = string.Join(',', required);
+            foreach (var g in entries)
+            {
+                var chunkLines = string.Join('\n', new[] { header }.Concat(g.Select(e => $"{e.Time:o},{e.Line}"))) + "\n";
+                var blobId = await _blobStorage.SaveAsync($"{dataSource.Symbol}_{g.Key:yyyyMMddHH}.csv", "text/csv", Encoding.UTF8.GetBytes(chunkLines), token).ConfigureAwait(false);
+                var start = g.Key;
+                var end = g.Key.AddHours(1);
+                var overlap = existing.FirstOrDefault(c => c.StartTime < end && c.EndTime > start);
+                var chunkId = overlap?.DataChunkId ?? Guid.NewGuid();
+                await _commandBus.PublishAsync(new DataChunkRegisterCommand(DataSourceId.With(dataSource.DataSourceId))
+                {
+                    DataChunkId = chunkId,
+                    BlobId = blobId,
+                    StartTime = start,
+                    EndTime = end,
+                }, token).ConfigureAwait(false);
+            }
+
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to process csv file");
+            return false;
+        }
+    }
+}

--- a/api/Stratrack.Api/Models/DataSourceCreateRequest.cs
+++ b/api/Stratrack.Api/Models/DataSourceCreateRequest.cs
@@ -12,6 +12,7 @@ public class DataSourceCreateRequest
     [Required]
     public string Timeframe { get; set; } = "";
     [Required]
-    public string SourceType { get; set; } = "";
+    [MinLength(1)]
+    public List<string> Fields { get; set; } = [];
     public string? Description { get; set; }
 }

--- a/api/Stratrack.Api/Models/DataSourceDetail.cs
+++ b/api/Stratrack.Api/Models/DataSourceDetail.cs
@@ -6,7 +6,7 @@ public class DataSourceDetail
     public string Name { get; set; } = "";
     public string Symbol { get; set; } = "";
     public string Timeframe { get; set; } = "";
-    public string SourceType { get; set; } = "";
+    public List<string> Fields { get; set; } = [];
     public string? Description { get; set; }
     public DateTimeOffset CreatedAt { get; set; }
     public DateTimeOffset UpdatedAt { get; set; }

--- a/frontend/src/api/datasources.test.ts
+++ b/frontend/src/api/datasources.test.ts
@@ -12,7 +12,7 @@ describe("createDataSource", () => {
       name: "ds",
       symbol: "EURUSD",
       timeframe: "1m",
-      sourceType: "dukascopy",
+      fields: ["bid", "ask"],
     };
 
     await createDataSource(data);

--- a/frontend/src/api/datasources.ts
+++ b/frontend/src/api/datasources.ts
@@ -2,7 +2,7 @@ export type NewDataSourceRequest = {
   name: string;
   symbol: string;
   timeframe: string;
-  sourceType: string;
+  fields: string[];
   description?: string;
 };
 
@@ -18,7 +18,7 @@ export type DataSourceDetail = {
   name: string;
   symbol: string;
   timeframe: string;
-  sourceType: string;
+  fields: string[];
   description?: string;
   createdAt: string;
   updatedAt: string;

--- a/frontend/src/features/datasources/DataSourceForm.stories.tsx
+++ b/frontend/src/features/datasources/DataSourceForm.stories.tsx
@@ -17,7 +17,8 @@ export const Default: Story = {
     const canvas = within(canvasElement);
     await userEvent.type(canvas.getByLabelText("名称"), "test");
     await userEvent.selectOptions(canvas.getByLabelText("時間足"), "tick");
-    await userEvent.selectOptions(canvas.getByLabelText("ソース種別"), "dukascopy");
+    await userEvent.click(canvas.getByLabelText("Bid"));
+    await userEvent.click(canvas.getByLabelText("Ask"));
     await expect(args.onChange).toHaveBeenCalled();
   },
 };

--- a/frontend/src/features/datasources/DataSourceForm.tsx
+++ b/frontend/src/features/datasources/DataSourceForm.tsx
@@ -2,13 +2,14 @@ import { useCallback } from "react";
 import Input from "../../components/Input";
 import Select from "../../components/Select";
 import Textarea from "../../components/Textarea";
+import Checkbox from "../../components/Checkbox";
 import { useLocalValue } from "../../hooks/useLocalValue";
 
 export type DataSourceFormValue = {
   name?: string;
   symbol?: string;
   timeframe?: string;
-  sourceType?: string;
+  fields?: string[];
   description?: string;
 };
 
@@ -23,11 +24,14 @@ const TIMEFRAME_OPTIONS = [
   { value: "5m", label: "5分足" },
 ];
 
-const SOURCE_TYPE_OPTIONS = [
-  { value: "dukascopy", label: "Dukascopy" },
-  { value: "mt4", label: "MT4" },
-  { value: "mt5", label: "MT5" },
-  { value: "custom_upload", label: "カスタムアップロード" },
+const FIELD_OPTIONS = [
+  { value: "bid", label: "Bid" },
+  { value: "ask", label: "Ask" },
+  { value: "open", label: "Open" },
+  { value: "high", label: "High" },
+  { value: "low", label: "Low" },
+  { value: "close", label: "Close" },
+  { value: "volume", label: "Volume" },
 ];
 
 function DataSourceForm({ value, onChange, hideSourceFields = false }: DataSourceFormProps) {
@@ -45,8 +49,14 @@ function DataSourceForm({ value, onChange, hideSourceFields = false }: DataSourc
     (v: string) => setLocalValue((cv) => ({ ...cv, timeframe: v })),
     [setLocalValue]
   );
-  const handleSourceTypeChange = useCallback(
-    (v: string) => setLocalValue((cv) => ({ ...cv, sourceType: v })),
+  const handleFieldChange = useCallback(
+    (field: string, checked: boolean) =>
+      setLocalValue((cv) => {
+        const set = new Set(cv.fields || []);
+        if (checked) set.add(field);
+        else set.delete(field);
+        return { ...cv, fields: Array.from(set) };
+      }),
     [setLocalValue]
   );
   const handleDescriptionChange = useCallback(
@@ -81,15 +91,18 @@ function DataSourceForm({ value, onChange, hideSourceFields = false }: DataSourc
             allowEmpty={false}
             fullWidth
           />
-          <Select
-            label="ソース種別"
-            value={localValue.sourceType || ""}
-            onChange={handleSourceTypeChange}
-            options={SOURCE_TYPE_OPTIONS}
-            required
-            allowEmpty={false}
-            fullWidth
-          />
+          <fieldset className="space-y-2">
+            <legend className="font-bold">Fields</legend>
+            {FIELD_OPTIONS.map((o) => (
+              <Checkbox
+                key={o.value}
+                label={o.label}
+                value={o.value}
+                checked={localValue.fields?.includes(o.value)}
+                onChange={(v) => handleFieldChange(o.value, v)}
+              />
+            ))}
+          </fieldset>
         </>
       )}
       <Textarea

--- a/frontend/src/routes/datasources/edit.stories.tsx
+++ b/frontend/src/routes/datasources/edit.stories.tsx
@@ -8,7 +8,7 @@ const sample = {
   name: "Sample",
   symbol: "EURUSD",
   timeframe: "1m",
-  sourceType: "dukascopy",
+  fields: ["bid", "ask"],
   description: "desc",
   createdAt: "",
   updatedAt: "",

--- a/frontend/src/routes/datasources/new.error.test.tsx
+++ b/frontend/src/routes/datasources/new.error.test.tsx
@@ -1,0 +1,42 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { createRoot } from "react-dom/client";
+import { act } from "react-dom/test-utils";
+import { RouterProvider, createMemoryRouter } from "react-router-dom";
+import NewDataSource from "./new";
+import * as api from "../../api/datasources";
+
+vi.mock("../../api/datasources");
+
+vi.mock("../../features/datasources/DataSourceForm", () => ({
+  default: ({ onChange }: { onChange?: (v: unknown) => void }) => {
+    onChange?.({
+      name: "ds1",
+      symbol: "EURUSD",
+      timeframe: "tick",
+      fields: ["bid", "ask"],
+    });
+    return null;
+  },
+}));
+
+describe("NewDataSource", () => {
+  it("displays error message when creation fails", async () => {
+    vi.mocked(api.createDataSource).mockRejectedValue(new Error("failed"));
+
+    const router = createMemoryRouter([{ path: "/", element: <NewDataSource /> }]);
+
+    const div = document.createElement("div");
+    await act(async () => {
+      const root = createRoot(div);
+      root.render(<RouterProvider router={router} />);
+    });
+
+    const form = div.querySelector("form")!;
+    await act(async () => {
+      form.requestSubmit();
+    });
+
+    expect(div.querySelector(".text-error")?.textContent).toBe("failed");
+  });
+});

--- a/frontend/src/routes/datasources/new.tsx
+++ b/frontend/src/routes/datasources/new.tsx
@@ -11,7 +11,12 @@ const NewDataSource = () => {
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!dataSource.name || !dataSource.symbol || !dataSource.timeframe || !dataSource.sourceType) {
+    if (
+      !dataSource.name ||
+      !dataSource.symbol ||
+      !dataSource.timeframe ||
+      !dataSource.fields?.length
+    ) {
       return;
     }
     setIsSubmitting(true);


### PR DESCRIPTION
## Summary
- update data source definitions to include `Fields` list and drop `SourceType`
- generalize CSV chunk parser to `CsvChunkService` supporting varied column orders
- adjust data source functions, infrastructure, and tests to new model
- update frontend forms and API types to configure fields

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run build`
- `dotnet test api/stratrack-backend.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6864e1e611ec8320aa59623ac8a49820