### PR TITLE
Improve form validation with Zod

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -15,6 +15,7 @@
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.6.0",
         "tailwindcss": "^4.1.1",
+        "zod": "^3.25.74",
         "zustand": "^5.0.5"
       },
       "devDependencies": {
@@ -6770,6 +6771,15 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/zod": {
+      "version": "3.25.74",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.74.tgz",
+      "integrity": "sha512-J8poo92VuhKjNknViHRAIuuN6li/EwFbAC8OedzI8uxpEPGiXHGQu9wemIAioIpqgfB4SySaJhdk0mH5Y4ICBg==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/zustand": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,7 @@
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.6.0",
     "tailwindcss": "^4.1.1",
+    "zod": "^3.25.74",
     "zustand": "^5.0.5"
   },
   "devDependencies": {

--- a/frontend/src/features/datasources/DataSourceForm.stories.tsx
+++ b/frontend/src/features/datasources/DataSourceForm.stories.tsx
@@ -22,3 +22,13 @@ export const Default: Story = {
     await expect(args.onChange).toHaveBeenCalled();
   },
 };
+
+export const Validation: Story = {
+  args: {},
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await userEvent.click(canvas.getByLabelText("名称"));
+    await userEvent.clear(canvas.getByLabelText("名称"));
+    await expect(canvas.getByText("名称は必須です")).toBeInTheDocument();
+  },
+};

--- a/frontend/src/hooks/useZodValidation.tsx
+++ b/frontend/src/hooks/useZodValidation.tsx
@@ -1,0 +1,27 @@
+import { useEffect, useState } from "react";
+import { ZodSchema } from "zod";
+
+export type ValidationErrors<T> = Partial<Record<keyof T, string>>;
+
+export function useZodValidation<T>(schema: ZodSchema<T>, value: T) {
+  const [errors, setErrors] = useState<ValidationErrors<T>>({});
+
+  useEffect(() => {
+    const result = schema.safeParse(value);
+    if (!result.success) {
+      const fieldErrors = result.error.formErrors.fieldErrors;
+      const newErrors: ValidationErrors<T> = {};
+      for (const key in fieldErrors) {
+        const message = fieldErrors[key as keyof typeof fieldErrors]?.[0];
+        if (message) {
+          newErrors[key as keyof T] = message;
+        }
+      }
+      setErrors(newErrors);
+    } else {
+      setErrors({});
+    }
+  }, [schema, value]);
+
+  return errors;
+}


### PR DESCRIPTION
## Summary
- integrate `zod` validation library for frontend
- add `useZodValidation` hook
- validate `DataSourceForm` fields and show messages
- update DataSourceForm stories with validation test

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686821a28d4883208ba609ea675b3061