### PR TITLE
Fix datasource form validation

### DIFF
--- a/frontend/src/components/Select.tsx
+++ b/frontend/src/components/Select.tsx
@@ -33,7 +33,15 @@ function Select({
 }: SelectProps) {
   const uniqueId = useMemo(() => id || `select-${Math.random().toString(36).slice(2, 9)}`, [id]);
 
-  const [localValue, setLocalValue] = useLocalValue(defaultValue || "", value, onChange);
+  const firstOption = useMemo(() => {
+    if (options.length === 0) return "";
+    const opt = options[0];
+    return typeof opt === "string" ? opt : opt.value;
+  }, [options]);
+
+  const initialValue = defaultValue ?? (allowEmpty ? "" : firstOption);
+
+  const [localValue, setLocalValue] = useLocalValue(initialValue, value, onChange);
 
   function handleChange(event: ChangeEvent<HTMLSelectElement>) {
     const selectedValue = event.target.value;

--- a/frontend/src/features/datasources/DataSourceForm.stories.tsx
+++ b/frontend/src/features/datasources/DataSourceForm.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
 import { fn, userEvent, within, expect } from "storybook/test";
-import DataSourceForm from "./DataSourceForm";
+import { useRef } from "react";
+import DataSourceForm, { DataSourceFormHandle } from "./DataSourceForm";
 
 const meta = {
   component: DataSourceForm,
@@ -23,12 +24,26 @@ export const Default: Story = {
   },
 };
 
+const ValidationDemo = (args: React.ComponentProps<typeof DataSourceForm>) => {
+  const ref = useRef<DataSourceFormHandle>(null);
+  return (
+    <div>
+      <DataSourceForm ref={ref} {...args} />
+      <button type="button" onClick={() => ref.current?.validate()}>
+        validate
+      </button>
+    </div>
+  );
+};
+
 export const Validation: Story = {
   args: {},
+  render: ValidationDemo,
   play: async ({ canvasElement }) => {
     const canvas = within(canvasElement);
     await userEvent.click(canvas.getByLabelText("名称"));
     await userEvent.clear(canvas.getByLabelText("名称"));
+    await userEvent.click(canvas.getByRole("button", { name: "validate" }));
     await expect(canvas.getByText("名称は必須です")).toBeInTheDocument();
   },
 };

--- a/frontend/src/hooks/useZodForm.tsx
+++ b/frontend/src/hooks/useZodForm.tsx
@@ -1,0 +1,56 @@
+import { useCallback, useEffect, useState } from "react";
+import { ZodSchema } from "zod";
+import { ValidationErrors } from "./useZodValidation";
+
+export type ZodFormHandle = {
+  validate: () => boolean;
+  reset: () => void;
+};
+
+export function useZodForm<T>(
+  schema: ZodSchema<T>,
+  value: T
+): {
+  errors: ValidationErrors<T>;
+  validate: () => boolean;
+  reset: () => void;
+} {
+  const [errors, setErrors] = useState<ValidationErrors<T>>({});
+  const [showErrors, setShowErrors] = useState(false);
+
+  const runValidation = useCallback(() => {
+    const result = schema.safeParse(value);
+    if (!result.success) {
+      const fieldErrors = result.error.formErrors.fieldErrors;
+      const newErrors: ValidationErrors<T> = {} as ValidationErrors<T>;
+      for (const key in fieldErrors) {
+        const message = (fieldErrors as Record<string, string[]>)[key]?.[0];
+        if (message) {
+          newErrors[key as keyof T] = message;
+        }
+      }
+      setErrors(newErrors);
+      return false;
+    }
+    setErrors({});
+    return true;
+  }, [schema, value]);
+
+  useEffect(() => {
+    if (showErrors) {
+      runValidation();
+    }
+  }, [showErrors, runValidation]);
+
+  const validate = useCallback(() => {
+    setShowErrors(true);
+    return runValidation();
+  }, [runValidation]);
+
+  const reset = useCallback(() => {
+    setShowErrors(false);
+    setErrors({});
+  }, []);
+
+  return { errors: showErrors ? errors : {}, validate, reset };
+}

--- a/frontend/src/routes/datasources/edit.tsx
+++ b/frontend/src/routes/datasources/edit.tsx
@@ -1,4 +1,4 @@
-import { FormEvent, useEffect, useState } from "react";
+import { FormEvent, useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
 import {
   getDataSource,
@@ -6,7 +6,10 @@ import {
   deleteDataSource,
   DataSourceDetail,
 } from "../../api/datasources";
-import DataSourceForm, { DataSourceFormValue } from "../../features/datasources/DataSourceForm";
+import DataSourceForm, {
+  DataSourceFormHandle,
+  DataSourceFormValue,
+} from "../../features/datasources/DataSourceForm";
 
 const EditDataSource = () => {
   const { dataSourceId } = useParams<{ dataSourceId: string }>();
@@ -14,6 +17,7 @@ const EditDataSource = () => {
   const navigate = useNavigate();
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
+  const formRef = useRef<DataSourceFormHandle>(null);
 
   useEffect(() => {
     if (dataSourceId) {
@@ -33,7 +37,10 @@ const EditDataSource = () => {
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!dataSourceId || !dataSource.name) {
+    const form = e.currentTarget;
+    const validHtml = form.reportValidity();
+    const validForm = formRef.current?.validate() ?? true;
+    if (!validHtml || !validForm || !dataSourceId) {
       return;
     }
     setIsSubmitting(true);
@@ -86,7 +93,12 @@ const EditDataSource = () => {
       <section>
         <form className="space-y-4" onSubmit={handleSubmit}>
           {error && <p className="text-error">{error}</p>}
-          <DataSourceForm value={dataSource} onChange={handleFormChange} hideSourceFields />
+          <DataSourceForm
+            ref={formRef}
+            value={dataSource}
+            onChange={handleFormChange}
+            hideSourceFields
+          />
           <button
             type="submit"
             className="mt-4 bg-primary text-primary-content py-2 px-4 rounded"

--- a/frontend/src/routes/datasources/new.tsx
+++ b/frontend/src/routes/datasources/new.tsx
@@ -1,17 +1,21 @@
-import { FormEvent, useState } from "react";
+import { FormEvent, useRef, useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { createDataSource, NewDataSourceRequest } from "../../api/datasources";
-import DataSourceForm from "../../features/datasources/DataSourceForm";
+import DataSourceForm, { DataSourceFormHandle } from "../../features/datasources/DataSourceForm";
 
 const NewDataSource = () => {
   const navigate = useNavigate();
   const [dataSource, setDataSource] = useState<Partial<NewDataSourceRequest>>({});
+  const formRef = useRef<DataSourceFormHandle>(null);
   const [error, setError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
 
   const handleSubmit = async (e: FormEvent<HTMLFormElement>) => {
     e.preventDefault();
-    if (!dataSource.name || !dataSource.symbol || !dataSource.timeframe || !dataSource.format) {
+    const form = e.currentTarget;
+    const validHtml = form.reportValidity();
+    const validForm = formRef.current?.validate() ?? true;
+    if (!validHtml || !validForm) {
       return;
     }
     setIsSubmitting(true);
@@ -34,7 +38,7 @@ const NewDataSource = () => {
       <section>
         <form className="space-y-4" onSubmit={handleSubmit}>
           {error && <p className="text-error">{error}</p>}
-          <DataSourceForm value={dataSource} onChange={setDataSource} />
+          <DataSourceForm ref={formRef} value={dataSource} onChange={setDataSource} />
           <button
             type="submit"
             className="mt-4 bg-primary text-primary-content py-2 px-4 rounded"


### PR DESCRIPTION
## Summary
- add `useZodForm` hook to handle validation on submit
- update DataSourceForm to expose validate and hide errors until validation
- ensure Select without empty option uses first option as initial value
- update datasource routes and stories to use the new validation API

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68682b8d1a74832084d445e32783c479