### PR TITLE
Fix enum parsing and add model deserialization tests

### DIFF
--- a/api/Stratrack.Api.Tests/ModelDeserializationTests.cs
+++ b/api/Stratrack.Api.Tests/ModelDeserializationTests.cs
@@ -1,0 +1,89 @@
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Stratrack.Api.Domain.DataSources;
+using Stratrack.Api.Models;
+
+namespace Stratrack.Api.Tests;
+
+[TestClass]
+public class ModelDeserializationTests
+{
+    private static JsonSerializerOptions CreateOptions()
+    {
+        var options = new JsonSerializerOptions
+        {
+            AllowTrailingCommas = true,
+            DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+            PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+            PropertyNameCaseInsensitive = true,
+        };
+        options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
+        return options;
+    }
+
+    [TestMethod]
+    public void DataSourceCreateRequest_CanDeserialize()
+    {
+        var json = "{\"name\":\"Dukascopy - USDJPY\",\"symbol\":\"USDJPY\",\"volume\":\"actual\",\"timeframe\":\"tick\",\"format\":\"tick\"}";
+        var model = JsonSerializer.Deserialize<DataSourceCreateRequest>(json, CreateOptions())!;
+        Assert.AreEqual("Dukascopy - USDJPY", model.Name);
+        Assert.AreEqual("USDJPY", model.Symbol);
+        Assert.AreEqual("tick", model.Timeframe);
+        Assert.AreEqual(DataFormat.Tick, model.Format);
+        Assert.AreEqual(VolumeType.Actual, model.Volume);
+    }
+
+    [TestMethod]
+    public void DataSourceUpdateRequest_CanDeserialize()
+    {
+        var json = "{\"name\":\"ds\",\"description\":\"desc\",\"tags\":[\"one\"]}";
+        var model = JsonSerializer.Deserialize<DataSourceUpdateRequest>(json, CreateOptions())!;
+        Assert.AreEqual("ds", model.Name);
+        Assert.AreEqual("desc", model.Description);
+        CollectionAssert.AreEqual(new[] { "one" }, model.Tags);
+    }
+
+    [TestMethod]
+    public void StrategyCreateRequest_CanDeserialize()
+    {
+        var json = "{\"name\":\"st\",\"description\":\"desc\",\"tags\":[\"t\"],\"template\":{\"foo\":\"bar\"},\"generatedCode\":\"code\"}";
+        var model = JsonSerializer.Deserialize<StrategyCreateRequest>(json, CreateOptions())!;
+        Assert.AreEqual("st", model.Name);
+        Assert.AreEqual("desc", model.Description);
+        CollectionAssert.AreEqual(new[] { "t" }, model.Tags);
+        Assert.AreEqual("bar", model.Template.GetProperty("foo").GetString());
+        Assert.AreEqual("code", model.GeneratedCode);
+    }
+
+    [TestMethod]
+    public void StrategyUpdateRequest_CanDeserialize()
+    {
+        var json = "{\"name\":\"st\",\"description\":\"desc\",\"tags\":[\"t\"],\"template\":{\"foo\":\"bar\"},\"generatedCode\":\"code\"}";
+        var model = JsonSerializer.Deserialize<StrategyUpdateRequest>(json, CreateOptions())!;
+        Assert.AreEqual("st", model.Name);
+        Assert.AreEqual("desc", model.Description);
+        CollectionAssert.AreEqual(new[] { "t" }, model.Tags);
+        Assert.AreEqual("bar", model.Template.GetProperty("foo").GetString());
+        Assert.AreEqual("code", model.GeneratedCode);
+    }
+
+    [TestMethod]
+    public void TickChunkUploadRequest_CanDeserialize()
+    {
+        var json = "{\"startTime\":\"2024-01-01T00:00:00Z\",\"endTime\":\"2024-01-01T01:00:00Z\",\"fileName\":\"file.csv\",\"base64Data\":\"QQ==\"}";
+        var model = JsonSerializer.Deserialize<TickChunkUploadRequest>(json, CreateOptions())!;
+        Assert.AreEqual(new DateTimeOffset(2024,1,1,0,0,0,TimeSpan.Zero), model.StartTime);
+        Assert.AreEqual(new DateTimeOffset(2024,1,1,1,0,0,TimeSpan.Zero), model.EndTime);
+        Assert.AreEqual("file.csv", model.FileName);
+        Assert.AreEqual("QQ==", model.Base64Data);
+    }
+
+    [TestMethod]
+    public void TickFileUploadRequest_CanDeserialize()
+    {
+        var json = "{\"fileName\":\"file.csv\",\"base64Data\":\"QQ==\"}";
+        var model = JsonSerializer.Deserialize<TickFileUploadRequest>(json, CreateOptions())!;
+        Assert.AreEqual("file.csv", model.FileName);
+        Assert.AreEqual("QQ==", model.Base64Data);
+    }
+}

--- a/api/Stratrack.Api/Program.cs
+++ b/api/Stratrack.Api/Program.cs
@@ -18,6 +18,7 @@ builder.Services
         options.DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull;
         options.PropertyNamingPolicy = JsonNamingPolicy.CamelCase;
         options.PropertyNameCaseInsensitive = true;
+        options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
     })
     .AddStratrack<StratrackDbContextProvider>();
 


### PR DESCRIPTION
## Summary
- handle enum values in API requests by adding `JsonStringEnumConverter`
- verify that all request models can be deserialized from JSON

## Testing
- `dotnet test api/stratrack-backend.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6868c6b32b108320867e8ecc08222d4a