### PR TITLE
Show data retention period

### DIFF
--- a/api/Stratrack.Api/Domain/DataSources/Queries/DataChunkRangeQuery.cs
+++ b/api/Stratrack.Api/Domain/DataSources/Queries/DataChunkRangeQuery.cs
@@ -1,0 +1,14 @@
+using EventFlow.Queries;
+
+namespace Stratrack.Api.Domain.DataSources.Queries;
+
+public class DataChunkRange
+{
+    public DateTimeOffset? StartTime { get; set; }
+    public DateTimeOffset? EndTime { get; set; }
+}
+
+public class DataChunkRangeQuery(Guid dataSourceId) : IQuery<DataChunkRange?>
+{
+    public Guid DataSourceId { get; } = dataSourceId;
+}

--- a/api/Stratrack.Api/Domain/DataSources/Queries/DataChunkRangeQueryHandler.cs
+++ b/api/Stratrack.Api/Domain/DataSources/Queries/DataChunkRangeQueryHandler.cs
@@ -1,0 +1,22 @@
+using EventFlow.EntityFramework;
+using EventFlow.Queries;
+using Microsoft.EntityFrameworkCore;
+
+namespace Stratrack.Api.Domain.DataSources.Queries;
+
+public class DataChunkRangeQueryHandler(IDbContextProvider<StratrackDbContext> dbContextProvider)
+    : IQueryHandler<DataChunkRangeQuery, DataChunkRange?>
+{
+    public async Task<DataChunkRange?> ExecuteQueryAsync(DataChunkRangeQuery query, CancellationToken cancellationToken)
+    {
+        using var context = dbContextProvider.CreateContext();
+        var chunks = context.DataChunks.Where(c => c.DataSourceId == query.DataSourceId);
+        var start = await chunks.MinAsync(c => (DateTimeOffset?)c.StartTime, cancellationToken).ConfigureAwait(false);
+        var end = await chunks.MaxAsync(c => (DateTimeOffset?)c.EndTime, cancellationToken).ConfigureAwait(false);
+        if (start == null || end == null)
+        {
+            return null;
+        }
+        return new DataChunkRange { StartTime = start, EndTime = end };
+    }
+}

--- a/api/Stratrack.Api/Domain/ServiceCollectionExtension.cs
+++ b/api/Stratrack.Api/Domain/ServiceCollectionExtension.cs
@@ -92,6 +92,7 @@ public static class ServiceCollectionExtension
             ef.UseEntityFrameworkReadModel<DukascopyJobReadModel, StratrackDbContext>();
             ef.AddQueryHandlers(typeof(DataSourceReadModelSearchQueryHandler));
             ef.AddQueryHandlers(typeof(DataChunkReadModelSearchQueryHandler));
+            ef.AddQueryHandlers(typeof(DataChunkRangeQueryHandler));
             ef.AddQueryHandlers(typeof(DukascopyJobReadModelSearchQueryHandler));
             ef.RegisterServices(s =>
             {

--- a/api/Stratrack.Api/Functions/DataSourceFunctions.cs
+++ b/api/Stratrack.Api/Functions/DataSourceFunctions.cs
@@ -203,6 +203,9 @@ public class DataSourceFunctions(ICommandBus commandBus, IQueryProcessor queryPr
         {
             return null;
         }
+
+        var range = await queryProcessor.ProcessAsync(new DataChunkRangeQuery(result.DataSourceId), token).ConfigureAwait(false);
+
         return new DataSourceDetail()
         {
             Id = result.DataSourceId,
@@ -214,6 +217,8 @@ public class DataSourceFunctions(ICommandBus commandBus, IQueryProcessor queryPr
             Description = result.Description,
             CreatedAt = result.CreatedAt,
             UpdatedAt = result.UpdatedAt,
+            StartTime = range?.StartTime,
+            EndTime = range?.EndTime,
         };
     }
 

--- a/api/Stratrack.Api/Models/DataSourceDetail.cs
+++ b/api/Stratrack.Api/Models/DataSourceDetail.cs
@@ -14,4 +14,6 @@ public class DataSourceDetail
     public string? Description { get; set; }
     public DateTimeOffset CreatedAt { get; set; }
     public DateTimeOffset UpdatedAt { get; set; }
+    public DateTimeOffset? StartTime { get; set; }
+    public DateTimeOffset? EndTime { get; set; }
 }

--- a/frontend/src/api/datasources.ts
+++ b/frontend/src/api/datasources.ts
@@ -27,6 +27,8 @@ export type DataSourceDetail = {
   description?: string;
   createdAt: string;
   updatedAt: string;
+  startTime?: string;
+  endTime?: string;
 };
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "";

--- a/frontend/src/routes/datasources/chart.tsx
+++ b/frontend/src/routes/datasources/chart.tsx
@@ -1,5 +1,6 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
+import { getDataSource } from "../../api/datasources";
 import { getDataStream } from "../../api/data";
 import LineChart, { LinePoint } from "../../components/LineChart";
 import TimeRangePicker, { TimeRange } from "../../components/TimeRangePicker";
@@ -8,8 +9,21 @@ import Button from "../../components/Button";
 const DataSourceChart = () => {
   const { dataSourceId } = useParams<{ dataSourceId: string }>();
   const [range, setRange] = useState<TimeRange>({});
+  const [dataRange, setDataRange] = useState<TimeRange>({});
   const [data, setData] = useState<LinePoint[]>([]);
   const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!dataSourceId) return;
+    getDataSource(dataSourceId)
+      .then((ds) => {
+        if (ds.startTime && ds.endTime) {
+          setRange({ from: ds.startTime, to: ds.endTime });
+          setDataRange({ from: ds.startTime, to: ds.endTime });
+        }
+      })
+      .catch((e) => console.error(e));
+  }, [dataSourceId]);
   const handleLoad = async () => {
     if (!dataSourceId || !range.from || !range.to) return;
     try {
@@ -31,6 +45,12 @@ const DataSourceChart = () => {
       <h2 className="text-2xl font-bold">チャート表示</h2>
       <div className="space-y-2">
         <TimeRangePicker label="期間" value={range} onChange={setRange} fullWidth />
+        {dataRange.from && dataRange.to && (
+          <p className="text-sm text-gray-500">
+            利用可能期間: {new Date(dataRange.from).toLocaleString()} -{" "}
+            {new Date(dataRange.to).toLocaleString()}
+          </p>
+        )}
         <Button onClick={handleLoad}>表示</Button>
         {error && <p className="text-error">{error}</p>}
       </div>


### PR DESCRIPTION
## Summary
- compute available data range for each data source
- expose start and end time via API
- show available data range on chart page and preset the picker

## Testing
- `dotnet test api/stratrack-backend.sln -c Release`
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686b03f0309483209aab0c8b069a7b92