### PR TITLE
Improve Dukascopy job page layout

### DIFF
--- a/frontend/src/routes/settings/DukascopyJobCard.stories.tsx
+++ b/frontend/src/routes/settings/DukascopyJobCard.stories.tsx
@@ -1,0 +1,26 @@
+import type { Meta, StoryObj } from "@storybook/react";
+import { fn, within, expect } from "storybook/test";
+import DukascopyJobCard, { JobState } from "./DukascopyJobCard";
+
+const meta = {
+  component: DukascopyJobCard,
+  args: {
+    pair: "EURUSD",
+    job: { start: new Date().toISOString().slice(0, 16), running: false } as JobState,
+    logs: [],
+    disabled: false,
+    onDateChange: fn(),
+    onToggle: fn(),
+  },
+} satisfies Meta<typeof DukascopyJobCard>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText("EURUSD")).toBeInTheDocument();
+  },
+};

--- a/frontend/src/routes/settings/DukascopyJobCard.tsx
+++ b/frontend/src/routes/settings/DukascopyJobCard.tsx
@@ -1,0 +1,40 @@
+import Button from "../../components/Button";
+import Input from "../../components/Input";
+import type { DukascopyJobLog } from "../../api/dukascopyJobs";
+
+export type JobState = { start: string; running: boolean; jobId?: string };
+
+type Props = {
+  pair: string;
+  job: JobState;
+  logs: DukascopyJobLog[];
+  disabled: boolean;
+  onDateChange: (pair: string, value: string) => void;
+  onToggle: (pair: string) => void;
+};
+
+const DukascopyJobCard = ({ pair, job, logs, disabled, onDateChange, onToggle }: Props) => (
+  <div className="rounded-xl border p-4 shadow space-y-2">
+    <h4 className="font-bold text-lg">{pair}</h4>
+    <Input
+      type="datetime-local"
+      value={job.start}
+      onChange={(v) => onDateChange(pair, v)}
+      fullWidth
+    />
+    <Button size="sm" onClick={() => onToggle(pair)} disabled={disabled}>
+      {job.running ? "停止" : "開始"}
+    </Button>
+    <details className="text-sm">
+      <summary className="cursor-pointer">履歴</summary>
+      <ul className="mt-1 pl-4 list-disc space-y-1 max-h-40 overflow-y-auto">
+        {logs.map((l) => (
+          <li key={l.executedAt}>{new Date(l.executedAt).toLocaleString()}</li>
+        ))}
+        {logs.length === 0 && <li>なし</li>}
+      </ul>
+    </details>
+  </div>
+);
+
+export default DukascopyJobCard;

--- a/frontend/src/routes/settings/dukascopy-jobs.tsx
+++ b/frontend/src/routes/settings/dukascopy-jobs.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from "react";
-import Input from "../../components/Input";
+import DukascopyJobCard, { JobState } from "./DukascopyJobCard";
 import {
   createDukascopyJob,
   startDukascopyJob,
@@ -11,8 +11,6 @@ import {
 } from "../../api/dukascopyJobs";
 
 const PAIRS = ["EURUSD", "USDJPY", "GBPUSD", "AUDUSD", "EURJPY"];
-
-type JobState = { start: string; running: boolean; jobId?: string };
 
 const initialState: Record<string, JobState> = Object.fromEntries(
   PAIRS.map((p) => [p, { start: new Date().toISOString().slice(0, 16), running: false }])
@@ -88,49 +86,19 @@ const DukascopyJobs = () => {
         <h2 className="text-2xl font-bold">Dukascopyジョブ管理</h2>
       </header>
       {error && <p className="text-error">{error}</p>}
-      <table className="table w-full">
-        <thead>
-          <tr>
-            <th>通貨ペア</th>
-            <th>開始日時</th>
-            <th>操作</th>
-            <th>ログ</th>
-          </tr>
-        </thead>
-        <tbody>
-          {PAIRS.map((pair) => {
-            const job = jobs[pair];
-            return (
-              <tr key={pair} className="hover">
-                <td>{pair}</td>
-                <td>
-                  <Input
-                    type="datetime-local"
-                    value={job.start}
-                    onChange={(v) => handleDateChange(pair, v)}
-                  />
-                </td>
-                <td>
-                  <button
-                    className="btn btn-primary btn-sm"
-                    onClick={() => handleToggle(pair)}
-                    disabled={isSubmitting}
-                  >
-                    {job.running ? "停止" : "開始"}
-                  </button>
-                </td>
-                <td className="text-sm">
-                  <ul>
-                    {logs[pair]?.map((l) => (
-                      <li key={l.executedAt}>{new Date(l.executedAt).toLocaleString()}</li>
-                    ))}
-                  </ul>
-                </td>
-              </tr>
-            );
-          })}
-        </tbody>
-      </table>
+      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+        {PAIRS.map((pair) => (
+          <DukascopyJobCard
+            key={pair}
+            pair={pair}
+            job={jobs[pair]}
+            logs={logs[pair] ?? []}
+            disabled={isSubmitting}
+            onDateChange={handleDateChange}
+            onToggle={handleToggle}
+          />
+        ))}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- refactor Dukascopy job management page
- introduce `DukascopyJobCard` component for clear job controls
- add storybook story for the new component

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686b6fe923cc8320a438cc426c1cb9e0