### PR TITLE
Add instructions on job date change

### DIFF
--- a/frontend/src/routes/settings/dukascopy-jobs.tsx
+++ b/frontend/src/routes/settings/dukascopy-jobs.tsx
@@ -84,6 +84,9 @@ const DukascopyJobs = () => {
     <div className="p-6 space-y-6">
       <header>
         <h2 className="text-2xl font-bold">Dukascopyジョブ管理</h2>
+        <p className="text-sm text-gray-600 mt-1">
+          日付を変更した後は一度ジョブを停止し、再度開始してください
+        </p>
       </header>
       {error && <p className="text-error">{error}</p>}
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">


### PR DESCRIPTION
## Summary
- show user instruction on Dukascopy job page about how to apply date changes

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686bb33996188320a83d3ffb9503b759