### PR TITLE
Fix timezone display for job dates

### DIFF
--- a/frontend/src/components/Input.stories.ts
+++ b/frontend/src/components/Input.stories.ts
@@ -50,3 +50,11 @@ export const FullWidth: Story = {
     fullWidth: true,
   },
 };
+
+export const Disabled: Story = {
+  args: {
+    label: "開始日時",
+    placeholder: "ロード中...",
+    disabled: true,
+  },
+};

--- a/frontend/src/components/Input.tsx
+++ b/frontend/src/components/Input.tsx
@@ -14,6 +14,7 @@ export type InputProps = {
   required?: boolean;
   error?: string;
   fullWidth?: boolean;
+  disabled?: boolean;
 };
 
 function Input({
@@ -28,6 +29,7 @@ function Input({
   required = false,
   error,
   fullWidth = false,
+  disabled = false,
 }: InputProps) {
   const uniqueId = useMemo(() => id || `input-${Math.random().toString(36).slice(2, 9)}`, [id]);
 
@@ -56,6 +58,7 @@ function Input({
         onChange={handleChange}
         required={required}
         className={cn(fullWidth ? "w-full" : null, "input", error ? "input-error" : "")}
+        disabled={disabled}
       />
       {error && <p className="text-sm text-error">{error}</p>}
     </div>

--- a/frontend/src/routes/settings/DukascopyJobCard.stories.tsx
+++ b/frontend/src/routes/settings/DukascopyJobCard.stories.tsx
@@ -1,12 +1,13 @@
 import type { Meta, StoryObj } from "@storybook/react";
 import { fn, within, expect } from "storybook/test";
 import DukascopyJobCard, { JobState } from "./DukascopyJobCard";
+import { toDateTimeLocalString } from "../../utils";
 
 const meta = {
   component: DukascopyJobCard,
   args: {
     pair: "EURUSD",
-    job: { start: new Date().toISOString().slice(0, 16), running: false } as JobState,
+    job: { start: toDateTimeLocalString(new Date()), running: false } as JobState,
     logs: [],
     disabled: false,
     onDateChange: fn(),

--- a/frontend/src/routes/settings/DukascopyJobCard.tsx
+++ b/frontend/src/routes/settings/DukascopyJobCard.tsx
@@ -18,28 +18,33 @@ type Props = {
   onToggle: (pair: string) => void;
 };
 
-const DukascopyJobCard = ({ pair, job, logs, disabled, onDateChange, onToggle }: Props) => (
-  <div className="rounded-xl border p-4 shadow space-y-2">
-    <h4 className="font-bold text-lg">{pair}</h4>
-    <Input
-      type="datetime-local"
-      value={job.start}
-      onChange={(v) => onDateChange(pair, v)}
-      fullWidth
-    />
-    <Button size="sm" onClick={() => onToggle(pair)} disabled={disabled}>
-      {job.running ? "停止" : "開始"}
-    </Button>
-    <details className="text-sm">
-      <summary className="cursor-pointer">履歴</summary>
-      <ul className="mt-1 pl-4 list-disc space-y-1 max-h-40 overflow-y-auto">
-        {logs.map((l) => (
-          <li key={l.executedAt}>{new Date(l.executedAt).toLocaleString()}</li>
-        ))}
-        {logs.length === 0 && <li>なし</li>}
-      </ul>
-    </details>
-  </div>
-);
+const DukascopyJobCard = ({ pair, job, logs, disabled, onDateChange, onToggle }: Props) => {
+  const isLoading = job.start === "";
+  return (
+    <div className="rounded-xl border p-4 shadow space-y-2">
+      <h4 className="font-bold text-lg">{pair}</h4>
+      <Input
+        type="datetime-local"
+        value={job.start}
+        placeholder={isLoading ? "ロード中..." : undefined}
+        onChange={(v) => onDateChange(pair, v)}
+        fullWidth
+        disabled={isLoading}
+      />
+      <Button size="sm" onClick={() => onToggle(pair)} disabled={disabled}>
+        {job.running ? "停止" : "開始"}
+      </Button>
+      <details className="text-sm">
+        <summary className="cursor-pointer">履歴</summary>
+        <ul className="mt-1 pl-4 list-disc space-y-1 max-h-40 overflow-y-auto">
+          {logs.map((l) => (
+            <li key={l.executedAt}>{new Date(l.executedAt).toLocaleString()}</li>
+          ))}
+          {logs.length === 0 && <li>なし</li>}
+        </ul>
+      </details>
+    </div>
+  );
+};
 
 export default DukascopyJobCard;

--- a/frontend/src/routes/settings/dukascopy-jobs.tsx
+++ b/frontend/src/routes/settings/dukascopy-jobs.tsx
@@ -18,7 +18,7 @@ const initialState: Record<string, JobState> = Object.fromEntries(
   PAIRS.map((p) => [
     p,
     {
-      start: toDateTimeLocalString(new Date()),
+      start: "",
       running: false,
       dataSourceId: undefined,
     },
@@ -65,6 +65,11 @@ const DukascopyJobs = () => {
     const job = jobs[pair];
     setIsSubmitting(true);
     setError(null);
+    if (!job.start) {
+      setError("開始日時を指定してください");
+      setIsSubmitting(false);
+      return;
+    }
     try {
       if (job.running) {
         if (job.jobId) {

--- a/frontend/src/routes/settings/dukascopy-jobs.tsx
+++ b/frontend/src/routes/settings/dukascopy-jobs.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import DukascopyJobCard, { JobState } from "./DukascopyJobCard";
+import { toDateTimeLocalString } from "../../utils";
 import {
   createDukascopyJob,
   startDukascopyJob,
@@ -17,7 +18,7 @@ const initialState: Record<string, JobState> = Object.fromEntries(
   PAIRS.map((p) => [
     p,
     {
-      start: new Date().toISOString().slice(0, 16),
+      start: toDateTimeLocalString(new Date()),
       running: false,
       dataSourceId: undefined,
     },
@@ -39,7 +40,7 @@ const DukascopyJobs = () => {
           items.map(async (j: DukascopyJobSummary) => {
             if (PAIRS.includes(j.symbol)) {
               state[j.symbol] = {
-                start: j.startTime.slice(0, 16),
+                start: toDateTimeLocalString(j.startTime),
                 running: j.isRunning,
                 jobId: j.id,
                 dataSourceId: j.dataSourceId,

--- a/frontend/src/utils.ts
+++ b/frontend/src/utils.ts
@@ -1,3 +1,10 @@
 export function cn(...classes: (string | undefined | false | null)[]) {
   return classes.filter(Boolean).join(" ");
 }
+
+export function toDateTimeLocalString(date: Date | string): string {
+  const d = typeof date === "string" ? new Date(date) : date;
+  const offset = d.getTimezoneOffset();
+  const local = new Date(d.getTime() - offset * 60_000);
+  return local.toISOString().slice(0, 16);
+}


### PR DESCRIPTION
## Summary
- convert API `startTime` into local timezone for display
- add `toDateTimeLocalString` utility
- update storybook to use new helper

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`
- `dotnet test api/stratrack-backend.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_686bb7b7dfdc8320bc12a19bd6875110