### PR TITLE
Add success logs to Dukascopy jobs

### DIFF
--- a/api/Stratrack.Api/Domain/Dukascopy/Commands/DukascopyJobExecutedCommand.cs
+++ b/api/Stratrack.Api/Domain/Dukascopy/Commands/DukascopyJobExecutedCommand.cs
@@ -5,4 +5,5 @@ namespace Stratrack.Api.Domain.Dukascopy.Commands;
 public class DukascopyJobExecutedCommand(DukascopyJobId aggregateId) : Command<DukascopyJobAggregate, DukascopyJobId>(aggregateId)
 {
     public DateTimeOffset ExecutedAt { get; set; }
+    public bool IsSuccess { get; set; }
 }

--- a/api/Stratrack.Api/Domain/Dukascopy/Commands/DukascopyJobExecutedCommandHandler.cs
+++ b/api/Stratrack.Api/Domain/Dukascopy/Commands/DukascopyJobExecutedCommandHandler.cs
@@ -6,7 +6,7 @@ public class DukascopyJobExecutedCommandHandler : CommandHandler<DukascopyJobAgg
 {
     public override Task ExecuteAsync(DukascopyJobAggregate aggregate, DukascopyJobExecutedCommand command, CancellationToken cancellationToken)
     {
-        aggregate.LogExecution(command.ExecutedAt);
+        aggregate.LogExecution(command.ExecutedAt, command.IsSuccess);
         return Task.CompletedTask;
     }
 }

--- a/api/Stratrack.Api/Domain/Dukascopy/DukascopyJobAggregate.cs
+++ b/api/Stratrack.Api/Domain/Dukascopy/DukascopyJobAggregate.cs
@@ -66,9 +66,9 @@ public class DukascopyJobAggregate(DukascopyJobId id) : AggregateRoot<DukascopyJ
         }
     }
 
-    public void LogExecution(DateTimeOffset executedAt)
+    public void LogExecution(DateTimeOffset executedAt, bool isSuccess)
     {
-        Emit(new DukascopyJobExecutedEvent(executedAt));
+        Emit(new DukascopyJobExecutedEvent(executedAt, isSuccess));
     }
 
     public void Apply(DukascopyJobCreatedEvent aggregateEvent)

--- a/api/Stratrack.Api/Domain/Dukascopy/DukascopyJobExecutionReadModel.cs
+++ b/api/Stratrack.Api/Domain/Dukascopy/DukascopyJobExecutionReadModel.cs
@@ -12,12 +12,14 @@ public class DukascopyJobExecutionReadModel : IReadModel,
     public string Id { get; set; } = "";
     public Guid JobId { get; set; }
     public DateTimeOffset ExecutedAt { get; set; }
+    public bool IsSuccess { get; set; }
 
     public Task ApplyAsync(IReadModelContext context, IDomainEvent<DukascopyJobAggregate, DukascopyJobId, DukascopyJobExecutedEvent> domainEvent, CancellationToken cancellationToken)
     {
         Id = context.ReadModelId;
         JobId = domainEvent.AggregateIdentity.GetGuid();
         ExecutedAt = domainEvent.AggregateEvent.ExecutedAt;
+        IsSuccess = domainEvent.AggregateEvent.IsSuccess;
         return Task.CompletedTask;
     }
 }

--- a/api/Stratrack.Api/Domain/Dukascopy/Events/DukascopyJobExecutedEvent.cs
+++ b/api/Stratrack.Api/Domain/Dukascopy/Events/DukascopyJobExecutedEvent.cs
@@ -4,7 +4,8 @@ using EventFlow.EventStores;
 namespace Stratrack.Api.Domain.Dukascopy.Events;
 
 [EventVersion("DukascopyJobExecuted", 1)]
-public class DukascopyJobExecutedEvent(DateTimeOffset executedAt) : AggregateEvent<DukascopyJobAggregate, DukascopyJobId>
+public class DukascopyJobExecutedEvent(DateTimeOffset executedAt, bool isSuccess) : AggregateEvent<DukascopyJobAggregate, DukascopyJobId>
 {
     public DateTimeOffset ExecutedAt { get; } = executedAt;
+    public bool IsSuccess { get; } = isSuccess;
 }

--- a/api/Stratrack.Api/Domain/Migrations/20250707124146_AddIsSuccessToJobExecution.Designer.cs
+++ b/api/Stratrack.Api/Domain/Migrations/20250707124146_AddIsSuccessToJobExecution.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Stratrack.Api.Domain;
 
@@ -11,9 +12,11 @@ using Stratrack.Api.Domain;
 namespace Stratrack.Api.Domain.Migrations
 {
     [DbContext(typeof(StratrackDbContext))]
-    partial class StratrackDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250707124146_AddIsSuccessToJobExecution")]
+    partial class AddIsSuccessToJobExecution
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/Stratrack.Api/Domain/Migrations/20250707124146_AddIsSuccessToJobExecution.cs
+++ b/api/Stratrack.Api/Domain/Migrations/20250707124146_AddIsSuccessToJobExecution.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Stratrack.Api.Domain.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddIsSuccessToJobExecution : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "IsSuccess",
+                table: "DukascopyJobExecutions",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "IsSuccess",
+                table: "DukascopyJobExecutions");
+        }
+    }
+}

--- a/api/Stratrack.Api/Models/DukascopyJobLog.cs
+++ b/api/Stratrack.Api/Models/DukascopyJobLog.cs
@@ -3,4 +3,5 @@ namespace Stratrack.Api.Models;
 public class DukascopyJobLog
 {
     public DateTimeOffset ExecutedAt { get; set; }
+    public bool IsSuccess { get; set; }
 }


### PR DESCRIPTION
## Summary
- record job execution success in the API
- log timer executions
- expose success flag from API
- add DB migration for IsSuccess column

## Testing
- `dotnet test api/stratrack-backend.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686bbf14ae048320846892ace13dc788