### PR TITLE
Fix empty job date field loading state

### DIFF
--- a/frontend/src/routes/settings/DukascopyJobCard.stories.tsx
+++ b/frontend/src/routes/settings/DukascopyJobCard.stories.tsx
@@ -7,7 +7,11 @@ const meta = {
   component: DukascopyJobCard,
   args: {
     pair: "EURUSD",
-    job: { start: toDateTimeLocalString(new Date()), running: false } as JobState,
+    job: {
+      start: toDateTimeLocalString(new Date()),
+      running: false,
+      loaded: true,
+    } as JobState,
     logs: [],
     disabled: false,
     onDateChange: fn(),

--- a/frontend/src/routes/settings/DukascopyJobCard.tsx
+++ b/frontend/src/routes/settings/DukascopyJobCard.tsx
@@ -7,6 +7,7 @@ export type JobState = {
   running: boolean;
   jobId?: string;
   dataSourceId?: string;
+  loaded: boolean;
 };
 
 type Props = {
@@ -19,7 +20,7 @@ type Props = {
 };
 
 const DukascopyJobCard = ({ pair, job, logs, disabled, onDateChange, onToggle }: Props) => {
-  const isLoading = job.start === "";
+  const isLoading = !job.loaded;
   return (
     <div className="rounded-xl border p-4 shadow space-y-2">
       <h4 className="font-bold text-lg">{pair}</h4>

--- a/frontend/src/routes/settings/dukascopy-jobs.tsx
+++ b/frontend/src/routes/settings/dukascopy-jobs.tsx
@@ -21,6 +21,7 @@ const initialState: Record<string, JobState> = Object.fromEntries(
       start: "",
       running: false,
       dataSourceId: undefined,
+      loaded: false,
     },
   ])
 );
@@ -44,12 +45,16 @@ const DukascopyJobs = () => {
                 running: j.isRunning,
                 jobId: j.id,
                 dataSourceId: j.dataSourceId,
+                loaded: true,
               };
               const logs = await listDukascopyJobLogs(j.id).catch(() => []);
               logState[j.symbol] = logs;
             }
           })
         ).then(() => {
+          for (const p of PAIRS) {
+            state[p] = { ...state[p], loaded: true };
+          }
           setJobs(state);
           setLogs(logState);
         });


### PR DESCRIPTION
## Summary
- allow input when Dukascopy job has no start date
- update storybook fixtures

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686bd41565688320aaff6c853e987837