### PR TITLE
Gracefully handle missing Dukascopy data

### DIFF
--- a/api/Stratrack.Api.Tests/DukascopyClientTests.cs
+++ b/api/Stratrack.Api.Tests/DukascopyClientTests.cs
@@ -1,0 +1,19 @@
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Stratrack.Api.Infrastructure;
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Stratrack.Api.Tests;
+
+[TestClass]
+public class DukascopyClientTests
+{
+    [TestMethod]
+    public async Task GetTickDataAsync_ReturnsNullForNotFound()
+    {
+        var client = new DukascopyClient();
+        var data = await client.GetTickDataAsync("EURUSD", new DateTimeOffset(2000,1,1,0,0,0,TimeSpan.Zero), CancellationToken.None);
+        Assert.IsNull(data);
+    }
+}

--- a/api/Stratrack.Api/Domain/Dukascopy/DukascopyFetchService.cs
+++ b/api/Stratrack.Api/Domain/Dukascopy/DukascopyFetchService.cs
@@ -61,7 +61,8 @@ public class DukascopyFetchService(
         var chunks = await _queryProcessor.ProcessAsync(new DataChunkReadModelSearchQuery(ds.DataSourceId), token).ConfigureAwait(false);
         var lastEnd = chunks.OrderBy(c => c.EndTime).LastOrDefault()?.EndTime ?? startTime;
         var current = lastEnd;
-        while (current < DateTimeOffset.UtcNow)
+        var maxTime = DateTimeOffset.UtcNow.AddHours(-1);
+        while (current <= maxTime)
         {
             var data = await _client.GetTickDataAsync(ds.Symbol, current, token).ConfigureAwait(false);
             if (data != null && data.Length > 0)

--- a/api/Stratrack.Api/Domain/Dukascopy/IDukascopyClient.cs
+++ b/api/Stratrack.Api/Domain/Dukascopy/IDukascopyClient.cs
@@ -2,5 +2,5 @@ namespace Stratrack.Api.Domain.Dukascopy;
 
 public interface IDukascopyClient
 {
-    Task<byte[]> GetTickDataAsync(string symbol, DateTimeOffset time, CancellationToken token);
+    Task<byte[]?> GetTickDataAsync(string symbol, DateTimeOffset time, CancellationToken token);
 }


### PR DESCRIPTION
## Summary
- return `null` when Dukascopy tick data file is not found
- skip data chunk registration when tick data is missing
- add regression test for `DukascopyClient`

## Testing
- `dotnet test api/stratrack-backend.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686bdf5a19008320aef94088cfe8dcfa