### PR TITLE
Replace deprecated chart lib

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,7 +14,6 @@
         "react-ace": "^14.0.1",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.6.0",
-        "react-stockcharts": "^0.7.8",
         "tailwindcss": "^4.1.1",
         "zod": "^3.25.74",
         "zustand": "^5.0.5"
@@ -5528,42 +5527,6 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
-      }
-    },
-    "node_modules/react-stockcharts": {
-      "version": "0.7.8",
-      "resolved": "https://registry.npmjs.org/react-stockcharts/-/react-stockcharts-0.7.8.tgz",
-      "integrity": "sha512-swtnTFrp8+82dDGhuI3gg2qvO7irU/dz210k3KtmRiZGMwrmdWBsfYGRrctKRK2OSm+C7G4WgbhKo0pdfFlwyQ==",
-      "license": "MIT",
-      "dependencies": {
-        "d3-array": "^1.2.1",
-        "d3-collection": "^1.0.4",
-        "d3-force": "^1.1.0",
-        "d3-format": "^1.2.1",
-        "d3-interpolate": "^1.1.6",
-        "d3-path": "^1.0.5",
-        "d3-scale": "^1.0.7",
-        "d3-selection": "^1.2.0",
-        "d3-shape": "^1.2.0",
-        "d3-time": "^1.0.8",
-        "d3-time-format": "^2.1.1",
-        "debug": "^3.1.0",
-        "lodash.flattendeep": "^4.4.0",
-        "prop-types": "^15.6.0",
-        "save-svg-as-png": "^1.4.5"
-      },
-      "peerDependencies": {
-        "react": "^15.0.0 || ^16.0.0",
-        "react-dom": "^15.0.0 || ^16.0.0"
-      }
-    },
-    "node_modules/react-stockcharts/node_modules/debug": {
-      "version": "3.2.7",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-      "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.1"
       }
     },
     "node_modules/recast": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,6 @@
     "react-ace": "^14.0.1",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.6.0",
-    "react-stockcharts": "^0.7.8",
     "tailwindcss": "^4.1.1",
     "zod": "^3.25.74",
     "zustand": "^5.0.5"

--- a/frontend/src/components/CandlestickChart.stories.tsx
+++ b/frontend/src/components/CandlestickChart.stories.tsx
@@ -9,5 +9,14 @@ export default meta;
 type Story = StoryObj<typeof CandlestickChart>;
 
 export const Default: Story = {
-  render: () => <div style={{ width: 400, height: 250 }}>CandlestickChart</div>,
+  args: {
+    width: 300,
+    height: 150,
+    data: [
+      { date: new Date(0), open: 1, high: 1.2, low: 0.8, close: 1.1 },
+      { date: new Date(1), open: 1.1, high: 1.3, low: 1.0, close: 1.0 },
+      { date: new Date(2), open: 1.0, high: 1.2, low: 0.9, close: 1.15 },
+      { date: new Date(3), open: 1.15, high: 1.25, low: 1.05, close: 1.1 },
+    ],
+  },
 };

--- a/frontend/src/components/CandlestickChart.tsx
+++ b/frontend/src/components/CandlestickChart.tsx
@@ -1,8 +1,3 @@
-import { ChartCanvas, Chart } from "react-stockcharts";
-import { CandlestickSeries } from "react-stockcharts/lib/series";
-import { XAxis, YAxis } from "react-stockcharts/lib/axes";
-import { discontinuousTimeScaleProvider } from "react-stockcharts/lib/scale";
-
 export type Candle = {
   date: Date;
   open: number;
@@ -22,27 +17,38 @@ const CandlestickChart = ({ data, width = 600, height = 300 }: CandlestickChartP
     return <svg width={width} height={height}></svg>;
   }
 
-  const xScaleProvider = discontinuousTimeScaleProvider.inputDateAccessor((d: Candle) => d.date);
-  const { data: chartData, xScale, xAccessor, displayXAccessor } = xScaleProvider(data);
+  const minPrice = Math.min(...data.map((d) => d.low));
+  const maxPrice = Math.max(...data.map((d) => d.high));
+
+  const candleWidth = width / data.length;
+  const scaleY = (price: number) => {
+    if (maxPrice === minPrice) return height / 2;
+    return height - ((price - minPrice) / (maxPrice - minPrice)) * height;
+  };
 
   return (
-    <ChartCanvas
-      width={width}
-      height={height}
-      ratio={1}
-      data={chartData}
-      seriesName="Data"
-      xScale={xScale}
-      xAccessor={xAccessor}
-      displayXAccessor={displayXAccessor}
-      margin={{ left: 50, right: 50, top: 10, bottom: 30 }}
-    >
-      <Chart id={0} yExtents={(d: Candle) => [d.high, d.low]}>
-        <XAxis />
-        <YAxis />
-        <CandlestickSeries />
-      </Chart>
-    </ChartCanvas>
+    <svg width={width} height={height} className="border rounded">
+      {data.map((d, i) => {
+        const x = i * candleWidth + candleWidth / 2;
+        const openY = scaleY(d.open);
+        const closeY = scaleY(d.close);
+        const highY = scaleY(d.high);
+        const lowY = scaleY(d.low);
+        const color = d.close >= d.open ? "#4caf50" : "#f44336";
+        return (
+          <g key={i}>
+            <line x1={x} x2={x} y1={highY} y2={lowY} stroke={color} strokeWidth={1} />
+            <rect
+              x={x - candleWidth * 0.3}
+              y={Math.min(openY, closeY)}
+              width={candleWidth * 0.6}
+              height={Math.max(1, Math.abs(closeY - openY))}
+              fill={color}
+            />
+          </g>
+        );
+      })}
+    </svg>
   );
 };
 

--- a/frontend/src/routes/datasources/chart.tsx
+++ b/frontend/src/routes/datasources/chart.tsx
@@ -21,9 +21,7 @@ const DataSourceChart = () => {
       if (!dataSourceId) return;
       try {
         const csv = await getDataStream(dataSourceId, from, to);
-        const lines = csv
-          .split(/\r?\n/)
-          .filter((l) => l && !l.startsWith("time"));
+        const lines = csv.split(/\r?\n/).filter((l) => l && !l.startsWith("time"));
         if (dataSource?.format === "ohlc") {
           const candles: Candle[] = lines.map((l) => {
             const [t, o, h, low, c] = l.split(",");
@@ -59,9 +57,7 @@ const DataSourceChart = () => {
         if (ds.startTime && ds.endTime) {
           const end = new Date(ds.endTime).getTime();
           const start = ds.startTime ? new Date(ds.startTime).getTime() : end;
-          const defaultFrom = new Date(
-            Math.max(start, end - 24 * 60 * 60 * 1000)
-          ).toISOString();
+          const defaultFrom = new Date(Math.max(start, end - 24 * 60 * 60 * 1000)).toISOString();
           setRange({ from: defaultFrom, to: ds.endTime });
           setDataRange({ from: ds.startTime, to: ds.endTime });
           await loadData(defaultFrom, ds.endTime);

--- a/frontend/src/types/react-stockcharts.d.ts
+++ b/frontend/src/types/react-stockcharts.d.ts
@@ -1,4 +1,0 @@
-declare module "react-stockcharts";
-declare module "react-stockcharts/lib/series";
-declare module "react-stockcharts/lib/axes";
-declare module "react-stockcharts/lib/scale";


### PR DESCRIPTION
## Summary
- remove react-stockcharts dependency
- implement a simple candlestick chart in SVG
- update storybook example
- format chart route

## Testing
- `npm run format`
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run test` *(fails: vitest: not found)*
- `npm run build` *(fails: missing modules)*

------
https://chatgpt.com/codex/tasks/task_e_686c6876123483209f6ca4012970b515