### PR TITLE
Introduce chart.js for frontend charts

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,8 +10,12 @@
       "dependencies": {
         "@tailwindcss/vite": "^4.1.1",
         "ace-builds": "^1.39.1",
+        "chart.js": "^4.5.0",
+        "chartjs-adapter-date-fns": "^3.0.0",
+        "chartjs-chart-financial": "^0.2.1",
         "react": "^19.0.0",
         "react-ace": "^14.0.1",
+        "react-chartjs-2": "^5.3.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.6.0",
         "tailwindcss": "^4.1.1",
@@ -1233,6 +1237,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@kurkle/color": {
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/@kurkle/color/-/color-0.3.4.tgz",
+      "integrity": "sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==",
+      "license": "MIT"
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -3024,6 +3034,37 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chart.js": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/chart.js/-/chart.js-4.5.0.tgz",
+      "integrity": "sha512-aYeC/jDgSEx8SHWZvANYMioYMZ2KX02W6f6uVfyteuCGcadDLcYVHdfdygsTQkQ4TKn5lghoojAsPj5pu0SnvQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@kurkle/color": "^0.3.0"
+      },
+      "engines": {
+        "pnpm": ">=8"
+      }
+    },
+    "node_modules/chartjs-adapter-date-fns": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/chartjs-adapter-date-fns/-/chartjs-adapter-date-fns-3.0.0.tgz",
+      "integrity": "sha512-Rs3iEB3Q5pJ973J93OBTpnP7qoGwvq3nUnoMdtxO+9aoJof7UFcRbWcIDteXuYd1fgAvct/32T9qaLyLuZVwCg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": ">=2.8.0",
+        "date-fns": ">=2.0.0"
+      }
+    },
+    "node_modules/chartjs-chart-financial": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/chartjs-chart-financial/-/chartjs-chart-financial-0.2.1.tgz",
+      "integrity": "sha512-RI3zrszyf2YdW7ME8I5XDsicy6YaU+uA1XZmGddR3rdcQlGf4pSgGFK8O0PWPO5Szdc8wZ8qpns++yib6pWBaw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.0.0"
+      }
+    },
     "node_modules/check-error": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.1.tgz",
@@ -3129,120 +3170,6 @@
       "devOptional": true,
       "license": "MIT"
     },
-    "node_modules/d3-array": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
-      "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-collection": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
-      "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-color": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-1.4.1.tgz",
-      "integrity": "sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-dispatch": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
-      "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-force": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.2.1.tgz",
-      "integrity": "sha512-HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-collection": "1",
-        "d3-dispatch": "1",
-        "d3-quadtree": "1",
-        "d3-timer": "1"
-      }
-    },
-    "node_modules/d3-format": {
-      "version": "1.4.5",
-      "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
-      "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-interpolate": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-1.4.0.tgz",
-      "integrity": "sha512-V9znK0zc3jOPV4VD2zZn0sDhZU3WAE2bmlxdIwwQPPzPjvyLkd8B3JUVdS1IDUFDkWZ72c9qnv1GK2ZagTZ8EA==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-color": "1"
-      }
-    },
-    "node_modules/d3-path": {
-      "version": "1.0.9",
-      "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
-      "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-quadtree": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.7.tgz",
-      "integrity": "sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-scale": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/d3-scale/-/d3-scale-1.0.7.tgz",
-      "integrity": "sha512-KvU92czp2/qse5tUfGms6Kjig0AhHOwkzXG0+PqIJB3ke0WUv088AHMZI0OssO9NCkXt4RP8yju9rpH8aGB7Lw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-array": "^1.2.0",
-        "d3-collection": "1",
-        "d3-color": "1",
-        "d3-format": "1",
-        "d3-interpolate": "1",
-        "d3-time": "1",
-        "d3-time-format": "2"
-      }
-    },
-    "node_modules/d3-selection": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-1.4.2.tgz",
-      "integrity": "sha512-SJ0BqYihzOjDnnlfyeHT0e30k0K1+5sR3d5fNueCNeuhZTnGw4M4o8mqJchSwgKMXCNFo+e2VTChiSJ0vYtXkg==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-shape": {
-      "version": "1.3.7",
-      "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
-      "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-path": "1"
-      }
-    },
-    "node_modules/d3-time": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
-      "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==",
-      "license": "BSD-3-Clause"
-    },
-    "node_modules/d3-time-format": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
-      "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "d3-time": "1"
-      }
-    },
-    "node_modules/d3-timer": {
-      "version": "1.0.10",
-      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
-      "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==",
-      "license": "BSD-3-Clause"
-    },
     "node_modules/daisyui": {
       "version": "5.0.43",
       "resolved": "https://registry.npmjs.org/daisyui/-/daisyui-5.0.43.tgz",
@@ -3265,6 +3192,17 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/date-fns": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "license": "MIT",
+      "peer": true,
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/kossnocorp"
       }
     },
     "node_modules/debug": {
@@ -4788,12 +4726,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/lodash.flattendeep": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.flattendeep/-/lodash.flattendeep-4.4.0.tgz",
-      "integrity": "sha512-uHaJFihxmJcEX3kT4I23ABqKKalJ/zDrDg0lsFtc1h+3uw49SIJ5beyhx5ExVRti3AvKoOJngIj7xz3oylPdWQ==",
-      "license": "MIT"
-    },
     "node_modules/lodash.get": {
       "version": "4.4.2",
       "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
@@ -5008,6 +4940,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -5440,6 +5373,16 @@
         "react-dom": "^0.13.0 || ^0.14.0 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/react-chartjs-2": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/react-chartjs-2/-/react-chartjs-2-5.3.0.tgz",
+      "integrity": "sha512-UfZZFnDsERI3c3CZGxzvNJd02SHjaSJ8kgW1djn65H1KK8rehwTjyrRKOG3VTMG8wtHZ5rgAO5oTHtHi9GCCmw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "chart.js": "^4.1.1",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
     "node_modules/react-docgen": {
       "version": "8.0.0",
       "resolved": "https://registry.npmjs.org/react-docgen/-/react-docgen-8.0.0.tgz",
@@ -5671,12 +5614,6 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/save-svg-as-png": {
-      "version": "1.4.17",
-      "resolved": "https://registry.npmjs.org/save-svg-as-png/-/save-svg-as-png-1.4.17.tgz",
-      "integrity": "sha512-7QDaqJsVhdFPwviCxkgHiGm9omeaMBe1VKbHySWU6oFB2LtnGCcYS13eVoslUgq6VZC6Tjq/HddBd1K6p2PGpA==",
       "license": "MIT"
     },
     "node_modules/saxes": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -16,8 +16,12 @@
   "dependencies": {
     "@tailwindcss/vite": "^4.1.1",
     "ace-builds": "^1.39.1",
+    "chart.js": "^4.5.0",
+    "chartjs-adapter-date-fns": "^3.0.0",
+    "chartjs-chart-financial": "^0.2.1",
     "react": "^19.0.0",
     "react-ace": "^14.0.1",
+    "react-chartjs-2": "^5.3.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.6.0",
     "tailwindcss": "^4.1.1",

--- a/frontend/src/components/CandlestickChart.tsx
+++ b/frontend/src/components/CandlestickChart.tsx
@@ -1,3 +1,17 @@
+import {
+  Chart as ChartJS,
+  TimeScale,
+  LinearScale,
+  Tooltip,
+  Legend,
+  CategoryScale,
+  BarController,
+  BarElement,
+} from "chart.js";
+import { CandlestickController, CandlestickElement } from "chartjs-chart-financial";
+import "chartjs-adapter-date-fns";
+import { Chart } from "react-chartjs-2";
+
 export type Candle = {
   date: Date;
   open: number;
@@ -12,43 +26,44 @@ export type CandlestickChartProps = {
   height?: number;
 };
 
+ChartJS.register(
+  CandlestickController,
+  CandlestickElement,
+  TimeScale,
+  LinearScale,
+  Tooltip,
+  Legend,
+  CategoryScale,
+  BarController,
+  BarElement
+);
+
 const CandlestickChart = ({ data, width = 600, height = 300 }: CandlestickChartProps) => {
-  if (data.length === 0) {
-    return <svg width={width} height={height}></svg>;
-  }
-
-  const minPrice = Math.min(...data.map((d) => d.low));
-  const maxPrice = Math.max(...data.map((d) => d.high));
-
-  const candleWidth = width / data.length;
-  const scaleY = (price: number) => {
-    if (maxPrice === minPrice) return height / 2;
-    return height - ((price - minPrice) / (maxPrice - minPrice)) * height;
+  const chartData = {
+    datasets: [
+      {
+        label: "price",
+        data: data.map((d) => ({
+          x: d.date.getTime(),
+          o: d.open,
+          h: d.high,
+          l: d.low,
+          c: d.close,
+        })),
+      },
+    ],
   };
 
+  const options = {
+    responsive: false,
+    scales: {
+      x: { type: "time" },
+      y: { beginAtZero: false },
+    },
+  } as const;
+
   return (
-    <svg width={width} height={height} className="border rounded">
-      {data.map((d, i) => {
-        const x = i * candleWidth + candleWidth / 2;
-        const openY = scaleY(d.open);
-        const closeY = scaleY(d.close);
-        const highY = scaleY(d.high);
-        const lowY = scaleY(d.low);
-        const color = d.close >= d.open ? "#4caf50" : "#f44336";
-        return (
-          <g key={i}>
-            <line x1={x} x2={x} y1={highY} y2={lowY} stroke={color} strokeWidth={1} />
-            <rect
-              x={x - candleWidth * 0.3}
-              y={Math.min(openY, closeY)}
-              width={candleWidth * 0.6}
-              height={Math.max(1, Math.abs(closeY - openY))}
-              fill={color}
-            />
-          </g>
-        );
-      })}
-    </svg>
+    <Chart type="candlestick" data={chartData} options={options} width={width} height={height} />
   );
 };
 

--- a/frontend/src/components/LineChart.tsx
+++ b/frontend/src/components/LineChart.tsx
@@ -1,3 +1,16 @@
+import {
+  Chart as ChartJS,
+  LineElement,
+  LinearScale,
+  TimeScale,
+  PointElement,
+  Tooltip,
+  Legend,
+  ChartData,
+} from "chart.js";
+import "chartjs-adapter-date-fns";
+import { Line } from "react-chartjs-2";
+
 export type LinePoint = { x: number; y: number };
 
 export type LineChartProps = {
@@ -6,29 +19,30 @@ export type LineChartProps = {
   data: LinePoint[];
 };
 
+ChartJS.register(LineElement, LinearScale, TimeScale, PointElement, Tooltip, Legend);
+
 const LineChart = ({ width = 600, height = 300, data }: LineChartProps) => {
-  if (data.length === 0) {
-    return <svg width={width} height={height}></svg>;
-  }
+  const chartData: ChartData<"line", { x: number; y: number }[]> = {
+    datasets: [
+      {
+        label: "value",
+        data,
+        borderColor: "#3b82f6",
+        backgroundColor: "rgba(59,130,246,0.4)",
+        pointRadius: 0,
+      },
+    ],
+  };
 
-  const minX = Math.min(...data.map((d) => d.x));
-  const maxX = Math.max(...data.map((d) => d.x));
-  const minY = Math.min(...data.map((d) => d.y));
-  const maxY = Math.max(...data.map((d) => d.y));
+  const options = {
+    responsive: false,
+    scales: {
+      x: { type: "time" },
+      y: { beginAtZero: false },
+    },
+  } as const;
 
-  const points = data
-    .map((d) => {
-      const x = ((d.x - minX) / (maxX - minX)) * width;
-      const y = height - ((d.y - minY) / (maxY - minY)) * height;
-      return `${x},${y}`;
-    })
-    .join(" ");
-
-  return (
-    <svg width={width} height={height} className="border rounded">
-      <polyline fill="none" stroke="currentColor" strokeWidth="1" points={points} />
-    </svg>
-  );
+  return <Line data={chartData} options={options} width={width} height={height} />;
 };
 
 export default LineChart;


### PR DESCRIPTION
## Summary
- add `chart.js` and `react-chartjs-2` to frontend
- implement `LineChart` and `CandlestickChart` components using Chart.js
- hook up candlestick controller and time scale support

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_686c6b3cff308320a25407039741338f