### PR TITLE
Enable interactive chart navigation

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,6 +13,7 @@
         "chart.js": "^4.5.0",
         "chartjs-adapter-date-fns": "^3.0.0",
         "chartjs-chart-financial": "^0.2.1",
+        "chartjs-plugin-zoom": "^2.2.0",
         "react": "^19.0.0",
         "react-ace": "^14.0.1",
         "react-chartjs-2": "^5.3.0",
@@ -2171,6 +2172,12 @@
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
     },
+    "node_modules/@types/hammerjs": {
+      "version": "2.0.46",
+      "resolved": "https://registry.npmjs.org/@types/hammerjs/-/hammerjs-2.0.46.tgz",
+      "integrity": "sha512-ynRvcq6wvqexJ9brDMS4BnBLzmr0e14d6ZJTEShTBWKymQiHwlAyGu0ZPEFI2Fh1U53F7tN9ufClWM5KvqkKOw==",
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -3063,6 +3070,19 @@
       "license": "MIT",
       "peerDependencies": {
         "chart.js": "^4.0.0"
+      }
+    },
+    "node_modules/chartjs-plugin-zoom": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/chartjs-plugin-zoom/-/chartjs-plugin-zoom-2.2.0.tgz",
+      "integrity": "sha512-in6kcdiTlP6npIVLMd4zXZ08PDUXC52gZ4FAy5oyjk1zX3gKarXMAof7B9eFiisf9WOC3bh2saHg+J5WtLXZeA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hammerjs": "^2.0.45",
+        "hammerjs": "^2.0.8"
+      },
+      "peerDependencies": {
+        "chart.js": ">=3.2.0"
       }
     },
     "node_modules/check-error": {
@@ -4022,6 +4042,15 @@
       "integrity": "sha512-EtKwoO6kxCL9WO5xipiHTZlSzBm7WLT627TqC/uVRd0HKmq8NXyebnNYxDoBi7wt8eTWrUrKXCOVaFq9x1kgag==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/hammerjs": {
+      "version": "2.0.8",
+      "resolved": "https://registry.npmjs.org/hammerjs/-/hammerjs-2.0.8.tgz",
+      "integrity": "sha512-tSQXBXS/MWQOn/RKckawJ61vvsDpCom87JgxiYdGwHdOa0ht0vzUWDlfioofFCRU0L+6NGDt6XzbgoJvZkMeRQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.8.0"
+      }
     },
     "node_modules/has-flag": {
       "version": "4.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,6 +19,7 @@
     "chart.js": "^4.5.0",
     "chartjs-adapter-date-fns": "^3.0.0",
     "chartjs-chart-financial": "^0.2.1",
+    "chartjs-plugin-zoom": "^2.2.0",
     "react": "^19.0.0",
     "react-ace": "^14.0.1",
     "react-chartjs-2": "^5.3.0",

--- a/frontend/src/components/CandlestickChart.tsx
+++ b/frontend/src/components/CandlestickChart.tsx
@@ -8,6 +8,7 @@ import {
   BarController,
   BarElement,
 } from "chart.js";
+import zoomPlugin from "chartjs-plugin-zoom";
 import { CandlestickController, CandlestickElement } from "chartjs-chart-financial";
 import "chartjs-adapter-date-fns";
 import { Chart } from "react-chartjs-2";
@@ -24,6 +25,8 @@ export type CandlestickChartProps = {
   data: Candle[];
   width?: number;
   height?: number;
+  range?: { from: number; to: number };
+  onRangeChange?: (range: { from: number; to: number }) => void;
 };
 
 ChartJS.register(
@@ -37,8 +40,15 @@ ChartJS.register(
   BarController,
   BarElement
 );
+ChartJS.register(zoomPlugin);
 
-const CandlestickChart = ({ data, width = 600, height = 300 }: CandlestickChartProps) => {
+const CandlestickChart = ({
+  data,
+  width = 600,
+  height = 300,
+  range,
+  onRangeChange,
+}: CandlestickChartProps) => {
   const chartData = {
     datasets: [
       {
@@ -57,8 +67,28 @@ const CandlestickChart = ({ data, width = 600, height = 300 }: CandlestickChartP
   const options = {
     responsive: false,
     scales: {
-      x: { type: "time" },
+      x: { type: "time", min: range?.from, max: range?.to },
       y: { beginAtZero: false },
+    },
+    plugins: {
+      zoom: {
+        zoom: {
+          wheel: { enabled: true },
+          pinch: { enabled: true },
+          mode: "x",
+        },
+        pan: { enabled: true, mode: "x" },
+        onZoomComplete: ({ chart }: { chart: ChartJS }) => {
+          const from = chart.scales.x.min as number;
+          const to = chart.scales.x.max as number;
+          onRangeChange?.({ from, to });
+        },
+        onPanComplete: ({ chart }: { chart: ChartJS }) => {
+          const from = chart.scales.x.min as number;
+          const to = chart.scales.x.max as number;
+          onRangeChange?.({ from, to });
+        },
+      },
     },
   } as const;
 

--- a/frontend/src/components/LineChart.tsx
+++ b/frontend/src/components/LineChart.tsx
@@ -8,6 +8,7 @@ import {
   Legend,
   ChartData,
 } from "chart.js";
+import zoomPlugin from "chartjs-plugin-zoom";
 import "chartjs-adapter-date-fns";
 import { Line } from "react-chartjs-2";
 
@@ -17,11 +18,14 @@ export type LineChartProps = {
   width?: number;
   height?: number;
   data: LinePoint[];
+  range?: { from: number; to: number };
+  onRangeChange?: (range: { from: number; to: number }) => void;
 };
 
 ChartJS.register(LineElement, LinearScale, TimeScale, PointElement, Tooltip, Legend);
+ChartJS.register(zoomPlugin);
 
-const LineChart = ({ width = 600, height = 300, data }: LineChartProps) => {
+const LineChart = ({ width = 600, height = 300, data, range, onRangeChange }: LineChartProps) => {
   const chartData: ChartData<"line", { x: number; y: number }[]> = {
     datasets: [
       {
@@ -37,8 +41,28 @@ const LineChart = ({ width = 600, height = 300, data }: LineChartProps) => {
   const options = {
     responsive: false,
     scales: {
-      x: { type: "time" },
+      x: { type: "time", min: range?.from, max: range?.to },
       y: { beginAtZero: false },
+    },
+    plugins: {
+      zoom: {
+        zoom: {
+          wheel: { enabled: true },
+          pinch: { enabled: true },
+          mode: "x",
+        },
+        pan: { enabled: true, mode: "x" },
+        onZoomComplete: ({ chart }: { chart: ChartJS }) => {
+          const from = chart.scales.x.min as number;
+          const to = chart.scales.x.max as number;
+          onRangeChange?.({ from, to });
+        },
+        onPanComplete: ({ chart }: { chart: ChartJS }) => {
+          const from = chart.scales.x.min as number;
+          const to = chart.scales.x.max as number;
+          onRangeChange?.({ from, to });
+        },
+      },
     },
   } as const;
 


### PR DESCRIPTION
## Summary
- add `chartjs-plugin-zoom` to support zoom/pan
- make chart components notify range changes
- remove date range picker and button from chart page
- load data when chart range changes

## Testing
- `npm run format --prefix frontend`
- `npm run lint --prefix frontend`
- `npm run test --prefix frontend`
- `npm run build --prefix frontend`


------
https://chatgpt.com/codex/tasks/task_e_686c7042f92483208ace45b8142c62c3