### PR TITLE
Improve Dukascopy job logging and add log viewer

### DIFF
--- a/api/Stratrack.Api/Domain/Dukascopy/Commands/DukascopyJobExecutedCommand.cs
+++ b/api/Stratrack.Api/Domain/Dukascopy/Commands/DukascopyJobExecutedCommand.cs
@@ -6,4 +6,8 @@ public class DukascopyJobExecutedCommand(DukascopyJobId aggregateId) : Command<D
 {
     public DateTimeOffset ExecutedAt { get; set; }
     public bool IsSuccess { get; set; }
+    public string Symbol { get; set; } = string.Empty;
+    public DateTimeOffset TargetTime { get; set; }
+    public string? ErrorMessage { get; set; }
+    public double Duration { get; set; }
 }

--- a/api/Stratrack.Api/Domain/Dukascopy/Commands/DukascopyJobExecutedCommandHandler.cs
+++ b/api/Stratrack.Api/Domain/Dukascopy/Commands/DukascopyJobExecutedCommandHandler.cs
@@ -6,7 +6,13 @@ public class DukascopyJobExecutedCommandHandler : CommandHandler<DukascopyJobAgg
 {
     public override Task ExecuteAsync(DukascopyJobAggregate aggregate, DukascopyJobExecutedCommand command, CancellationToken cancellationToken)
     {
-        aggregate.LogExecution(command.ExecutedAt, command.IsSuccess);
+        aggregate.LogExecution(
+            command.ExecutedAt,
+            command.IsSuccess,
+            command.Symbol,
+            command.TargetTime,
+            command.ErrorMessage,
+            command.Duration);
         return Task.CompletedTask;
     }
 }

--- a/api/Stratrack.Api/Domain/Dukascopy/DukascopyJobAggregate.cs
+++ b/api/Stratrack.Api/Domain/Dukascopy/DukascopyJobAggregate.cs
@@ -66,9 +66,9 @@ public class DukascopyJobAggregate(DukascopyJobId id) : AggregateRoot<DukascopyJ
         }
     }
 
-    public void LogExecution(DateTimeOffset executedAt, bool isSuccess)
+    public void LogExecution(DateTimeOffset executedAt, bool isSuccess, string symbol, DateTimeOffset targetTime, string? errorMessage, double duration)
     {
-        Emit(new DukascopyJobExecutedEvent(executedAt, isSuccess));
+        Emit(new DukascopyJobExecutedEvent(executedAt, isSuccess, symbol, targetTime, errorMessage, duration));
     }
 
     public void Apply(DukascopyJobCreatedEvent aggregateEvent)

--- a/api/Stratrack.Api/Domain/Dukascopy/DukascopyJobExecutionReadModel.cs
+++ b/api/Stratrack.Api/Domain/Dukascopy/DukascopyJobExecutionReadModel.cs
@@ -13,6 +13,10 @@ public class DukascopyJobExecutionReadModel : IReadModel,
     public Guid JobId { get; set; }
     public DateTimeOffset ExecutedAt { get; set; }
     public bool IsSuccess { get; set; }
+    public string Symbol { get; set; } = string.Empty;
+    public DateTimeOffset TargetTime { get; set; }
+    public string? ErrorMessage { get; set; }
+    public double Duration { get; set; }
 
     public Task ApplyAsync(IReadModelContext context, IDomainEvent<DukascopyJobAggregate, DukascopyJobId, DukascopyJobExecutedEvent> domainEvent, CancellationToken cancellationToken)
     {
@@ -20,6 +24,10 @@ public class DukascopyJobExecutionReadModel : IReadModel,
         JobId = domainEvent.AggregateIdentity.GetGuid();
         ExecutedAt = domainEvent.AggregateEvent.ExecutedAt;
         IsSuccess = domainEvent.AggregateEvent.IsSuccess;
+        Symbol = domainEvent.AggregateEvent.Symbol;
+        TargetTime = domainEvent.AggregateEvent.TargetTime;
+        ErrorMessage = domainEvent.AggregateEvent.ErrorMessage;
+        Duration = domainEvent.AggregateEvent.Duration;
         return Task.CompletedTask;
     }
 }

--- a/api/Stratrack.Api/Domain/Dukascopy/Events/DukascopyJobExecutedEvent.cs
+++ b/api/Stratrack.Api/Domain/Dukascopy/Events/DukascopyJobExecutedEvent.cs
@@ -3,9 +3,20 @@ using EventFlow.EventStores;
 
 namespace Stratrack.Api.Domain.Dukascopy.Events;
 
-[EventVersion("DukascopyJobExecuted", 1)]
-public class DukascopyJobExecutedEvent(DateTimeOffset executedAt, bool isSuccess) : AggregateEvent<DukascopyJobAggregate, DukascopyJobId>
+[EventVersion("DukascopyJobExecuted", 2)]
+public class DukascopyJobExecutedEvent(
+    DateTimeOffset executedAt,
+    bool isSuccess,
+    string symbol,
+    DateTimeOffset targetTime,
+    string? errorMessage,
+    double duration
+) : AggregateEvent<DukascopyJobAggregate, DukascopyJobId>
 {
     public DateTimeOffset ExecutedAt { get; } = executedAt;
     public bool IsSuccess { get; } = isSuccess;
+    public string Symbol { get; } = symbol;
+    public DateTimeOffset TargetTime { get; } = targetTime;
+    public string? ErrorMessage { get; } = errorMessage;
+    public double Duration { get; } = duration;
 }

--- a/api/Stratrack.Api/Domain/Dukascopy/Queries/DukascopyJobExecutionPagedQuery.cs
+++ b/api/Stratrack.Api/Domain/Dukascopy/Queries/DukascopyJobExecutionPagedQuery.cs
@@ -1,0 +1,9 @@
+using EventFlow.Queries;
+
+namespace Stratrack.Api.Domain.Dukascopy.Queries;
+
+public class DukascopyJobExecutionPagedQuery(int page, int pageSize) : IQuery<IReadOnlyCollection<DukascopyJobExecutionReadModel>>
+{
+    public int Page { get; } = page;
+    public int PageSize { get; } = pageSize;
+}

--- a/api/Stratrack.Api/Domain/Dukascopy/Queries/DukascopyJobExecutionPagedQueryHandler.cs
+++ b/api/Stratrack.Api/Domain/Dukascopy/Queries/DukascopyJobExecutionPagedQueryHandler.cs
@@ -1,0 +1,20 @@
+using EventFlow.EntityFramework;
+using EventFlow.Queries;
+using Microsoft.EntityFrameworkCore;
+
+namespace Stratrack.Api.Domain.Dukascopy.Queries;
+
+public class DukascopyJobExecutionPagedQueryHandler(IDbContextProvider<StratrackDbContext> dbContextProvider) :
+    IQueryHandler<DukascopyJobExecutionPagedQuery, IReadOnlyCollection<DukascopyJobExecutionReadModel>>
+{
+    public async Task<IReadOnlyCollection<DukascopyJobExecutionReadModel>> ExecuteQueryAsync(DukascopyJobExecutionPagedQuery query, CancellationToken cancellationToken)
+    {
+        using var context = dbContextProvider.CreateContext();
+        return await context.DukascopyJobExecutions
+            .OrderByDescending(e => e.ExecutedAt)
+            .Skip((query.Page - 1) * query.PageSize)
+            .Take(query.PageSize)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+}

--- a/api/Stratrack.Api/Domain/Migrations/20250708024931_ExtendDukascopyJobExecution.Designer.cs
+++ b/api/Stratrack.Api/Domain/Migrations/20250708024931_ExtendDukascopyJobExecution.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Stratrack.Api.Domain;
 
@@ -11,9 +12,11 @@ using Stratrack.Api.Domain;
 namespace Stratrack.Api.Domain.Migrations
 {
     [DbContext(typeof(StratrackDbContext))]
-    partial class StratrackDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250708024931_ExtendDukascopyJobExecution")]
+    partial class ExtendDukascopyJobExecution
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/Stratrack.Api/Domain/Migrations/20250708024931_ExtendDukascopyJobExecution.cs
+++ b/api/Stratrack.Api/Domain/Migrations/20250708024931_ExtendDukascopyJobExecution.cs
@@ -1,0 +1,62 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Stratrack.Api.Domain.Migrations
+{
+    /// <inheritdoc />
+    public partial class ExtendDukascopyJobExecution : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<double>(
+                name: "Duration",
+                table: "DukascopyJobExecutions",
+                type: "float",
+                nullable: false,
+                defaultValue: 0.0);
+
+            migrationBuilder.AddColumn<string>(
+                name: "ErrorMessage",
+                table: "DukascopyJobExecutions",
+                type: "nvarchar(max)",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "Symbol",
+                table: "DukascopyJobExecutions",
+                type: "nvarchar(max)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddColumn<DateTimeOffset>(
+                name: "TargetTime",
+                table: "DukascopyJobExecutions",
+                type: "datetimeoffset",
+                nullable: false,
+                defaultValue: new DateTimeOffset(new DateTime(1, 1, 1, 0, 0, 0, 0, DateTimeKind.Unspecified), new TimeSpan(0, 0, 0, 0, 0)));
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "Duration",
+                table: "DukascopyJobExecutions");
+
+            migrationBuilder.DropColumn(
+                name: "ErrorMessage",
+                table: "DukascopyJobExecutions");
+
+            migrationBuilder.DropColumn(
+                name: "Symbol",
+                table: "DukascopyJobExecutions");
+
+            migrationBuilder.DropColumn(
+                name: "TargetTime",
+                table: "DukascopyJobExecutions");
+        }
+    }
+}

--- a/api/Stratrack.Api/Domain/ServiceCollectionExtension.cs
+++ b/api/Stratrack.Api/Domain/ServiceCollectionExtension.cs
@@ -99,6 +99,7 @@ public static class ServiceCollectionExtension
             ef.AddQueryHandlers(typeof(DataChunkRangeQueryHandler));
             ef.AddQueryHandlers(typeof(DukascopyJobReadModelSearchQueryHandler));
             ef.AddQueryHandlers(typeof(DukascopyJobExecutionReadModelSearchQueryHandler));
+            ef.AddQueryHandlers(typeof(DukascopyJobExecutionPagedQueryHandler));
             ef.RegisterServices(s =>
             {
                 s.AddSingleton<IBlobStorage, DatabaseBlobStorage>();

--- a/api/Stratrack.Api/Models/DukascopyJobLog.cs
+++ b/api/Stratrack.Api/Models/DukascopyJobLog.cs
@@ -4,4 +4,8 @@ public class DukascopyJobLog
 {
     public DateTimeOffset ExecutedAt { get; set; }
     public bool IsSuccess { get; set; }
+    public string Symbol { get; set; } = string.Empty;
+    public DateTimeOffset TargetTime { get; set; }
+    public string? ErrorMessage { get; set; }
+    public double Duration { get; set; }
 }

--- a/frontend/src/api/dukascopyJobs.ts
+++ b/frontend/src/api/dukascopyJobs.ts
@@ -91,12 +91,33 @@ export async function listDukascopyJobs(): Promise<DukascopyJobSummary[]> {
   return res.json();
 }
 
-export type DukascopyJobLog = { executedAt: string };
+export type DukascopyJobLog = {
+  executedAt: string;
+  isSuccess: boolean;
+  symbol: string;
+  targetTime: string;
+  errorMessage?: string;
+  duration: number;
+};
 
 export async function listDukascopyJobLogs(id: string): Promise<DukascopyJobLog[]> {
   const res = await fetch(`${API_BASE_URL}/api/dukascopy-job/${id}/logs`, {
     headers: { "x-functions-key": API_KEY },
   });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch dukascopy job logs: ${res.status}`);
+  }
+  return res.json();
+}
+
+export async function listAllDukascopyJobLogs(
+  page = 1,
+  pageSize = 100
+): Promise<DukascopyJobLog[]> {
+  const res = await fetch(
+    `${API_BASE_URL}/api/dukascopy-job/logs?page=${page}&pageSize=${pageSize}`,
+    { headers: { "x-functions-key": API_KEY } }
+  );
   if (!res.ok) {
     throw new Error(`Failed to fetch dukascopy job logs: ${res.status}`);
   }

--- a/frontend/src/routes/index.tsx
+++ b/frontend/src/routes/index.tsx
@@ -12,6 +12,7 @@ import UploadDataFile from "./datasources/upload";
 import DataSourceChart from "./datasources/chart";
 import Settings from "./settings";
 import DukascopyJobs from "./settings/dukascopy-jobs";
+import DukascopyLogs from "./settings/dukascopy-logs";
 
 export const routes = [
   {
@@ -31,6 +32,7 @@ export const routes = [
       { path: "data-sources/:dataSourceId/chart", element: <DataSourceChart /> },
       { path: "settings", element: <Settings /> },
       { path: "settings/dukascopy-jobs", element: <DukascopyJobs /> },
+      { path: "settings/dukascopy-logs", element: <DukascopyLogs /> },
     ],
   },
 ];

--- a/frontend/src/routes/settings/DukascopyJobCard.tsx
+++ b/frontend/src/routes/settings/DukascopyJobCard.tsx
@@ -39,7 +39,10 @@ const DukascopyJobCard = ({ pair, job, logs, disabled, onDateChange, onToggle }:
         <summary className="cursor-pointer">履歴</summary>
         <ul className="mt-1 pl-4 list-disc space-y-1 max-h-40 overflow-y-auto">
           {logs.map((l) => (
-            <li key={l.executedAt}>{new Date(l.executedAt).toLocaleString()}</li>
+            <li key={l.executedAt}>
+              {new Date(l.executedAt).toLocaleString()} - {new Date(l.targetTime).toLocaleString()}{" "}
+              -{l.isSuccess ? "成功" : `失敗: ${l.errorMessage ?? ""}`} ({Math.round(l.duration)}ms)
+            </li>
           ))}
           {logs.length === 0 && <li>なし</li>}
         </ul>

--- a/frontend/src/routes/settings/dukascopy-logs.stories.tsx
+++ b/frontend/src/routes/settings/dukascopy-logs.stories.tsx
@@ -1,0 +1,30 @@
+import { RouterProvider, createMemoryRouter } from "react-router-dom";
+import type { Meta, StoryObj } from "@storybook/react";
+import { within, expect } from "storybook/test";
+import { vi } from "vitest";
+import DukascopyLogs from "./dukascopy-logs";
+
+const router = createMemoryRouter([{ path: "/", element: <DukascopyLogs /> }]);
+
+const meta = {
+  component: DukascopyLogs,
+  render: () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => [],
+    }) as unknown as typeof fetch;
+    return <RouterProvider router={router} />;
+  },
+  parameters: { layout: "fullscreen" },
+} satisfies Meta<typeof DukascopyLogs>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  play: async ({ canvasElement }) => {
+    const canvas = within(canvasElement);
+    await expect(canvas.getByText(/Dukascopyログ/)).toBeInTheDocument();
+  },
+};

--- a/frontend/src/routes/settings/dukascopy-logs.tsx
+++ b/frontend/src/routes/settings/dukascopy-logs.tsx
@@ -1,0 +1,64 @@
+import { useEffect, useState } from "react";
+import { listAllDukascopyJobLogs, DukascopyJobLog } from "../../api/dukascopyJobs";
+import Button from "../../components/Button";
+
+const PAGE_SIZE = 50;
+
+const DukascopyLogs = () => {
+  const [logs, setLogs] = useState<DukascopyJobLog[]>([]);
+  const [page, setPage] = useState(1);
+
+  useEffect(() => {
+    listAllDukascopyJobLogs(page, PAGE_SIZE)
+      .then(setLogs)
+      .catch((err) => console.error(err));
+  }, [page]);
+
+  return (
+    <div className="p-6 space-y-6">
+      <header className="flex justify-between items-center">
+        <h2 className="text-2xl font-bold">Dukascopyログ</h2>
+      </header>
+      <table className="table table-sm">
+        <thead>
+          <tr>
+            <th>実行時刻</th>
+            <th>通貨</th>
+            <th>対象時刻</th>
+            <th>結果</th>
+            <th>エラー</th>
+            <th>時間(ms)</th>
+          </tr>
+        </thead>
+        <tbody>
+          {logs.map((l) => (
+            <tr key={l.executedAt + l.symbol}>
+              <td>{new Date(l.executedAt).toLocaleString()}</td>
+              <td>{l.symbol}</td>
+              <td>{new Date(l.targetTime).toLocaleString()}</td>
+              <td>{l.isSuccess ? "成功" : "失敗"}</td>
+              <td>{l.errorMessage ?? ""}</td>
+              <td>{Math.round(l.duration)}</td>
+            </tr>
+          ))}
+          {logs.length === 0 && (
+            <tr>
+              <td colSpan={6} className="text-center">
+                ログがありません
+              </td>
+            </tr>
+          )}
+        </tbody>
+      </table>
+      <div className="flex justify-between">
+        <Button onClick={() => setPage((p) => Math.max(1, p - 1))} disabled={page === 1}>
+          前へ
+        </Button>
+        <span>Page {page}</span>
+        <Button onClick={() => setPage((p) => p + 1)}>次へ</Button>
+      </div>
+    </div>
+  );
+};
+
+export default DukascopyLogs;

--- a/frontend/src/routes/settings/index.tsx
+++ b/frontend/src/routes/settings/index.tsx
@@ -20,6 +20,16 @@ const Settings = () => {
               開く
             </Link>
           </div>
+          <div className="rounded-xl border p-4 shadow">
+            <h4 className="font-bold">Dukascopyログ</h4>
+            <p className="text-sm text-gray-600">ジョブの実行履歴を確認します</p>
+            <Link
+              to="/settings/dukascopy-logs"
+              className="mt-2 bg-primary text-primary-content py-1 px-3 rounded"
+            >
+              開く
+            </Link>
+          </div>
         </div>
       </section>
     </div>


### PR DESCRIPTION
## Summary
- extend Dukascopy job execution event to include symbol, target time, error and duration
- persist new fields in read model and expose query for pagination
- add endpoint `GET /dukascopy-job/logs` for paginated logs
- create React page to list logs with paging
- update API and UI to use new log model
- add EF migration

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run build`
- `dotnet test api/stratrack-backend.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_686c81f0b2e0832085ac358a05aef843