### PR TITLE
Refactor job naming and adjust enable endpoint

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -42,5 +42,5 @@ Azurite と Azure Functions Core Tools を利用することで、Durable Functi
 
 1. 別ターミナルで `azurite` を実行し、ストレージエミュレーターを起動します。Docker を使用する場合は `docker run -p 10000:10000 -p 10001:10001 -p 10002:10002 mcr.microsoft.com/azure-storage/azurite` を実行します。
 2. `Stratrack.Api` ディレクトリで `func start` を実行し Functions ホストを起動します。
-3. `http://localhost:7071/api/swagger/ui` から `CreateDukascopyJob` などのエンドポイントを呼び出し、`EnableDukascopyJob` を実行すると `DukascopyJobOrchestrator` が起動してジョブが開始されます。
+3. `http://localhost:7071/api/swagger/ui` から `CreateDukascopyJob` などのエンドポイントを呼び出してください。
 4. オーケストレーターの状態は `func durable get-instances` で確認できます。

--- a/api/Stratrack.Api.Tests/DukascopyJobFunctionsTests.cs
+++ b/api/Stratrack.Api.Tests/DukascopyJobFunctionsTests.cs
@@ -63,19 +63,20 @@ public class DukascopyJobFunctionsTests
             .WithUrl($"http://localhost/api/dukascopy-job/{id}/enable")
             .WithMethod(HttpMethod.Post)
             .Build();
-        var client = new Mock<DurableTaskClient>("test");
-        client.Setup(c => c.ScheduleNewOrchestrationInstanceAsync(
-            It.IsAny<TaskName>(),
-            It.IsAny<object?>(),
-            It.IsAny<StartOrchestrationOptions?>(),
-            It.IsAny<CancellationToken>())).ReturnsAsync("instance");
-        var startRes = await func.EnableJob(startReq, id, client.Object, CancellationToken.None);
+        var startRes = await func.EnableJob(startReq, id, CancellationToken.None);
         Assert.AreEqual(HttpStatusCode.Accepted, startRes.StatusCode);
         using (var ctx = provider.GetRequiredService<IDbContextProvider<StratrackDbContext>>().CreateContext())
         {
             var ds = await ctx.DataSources.FirstAsync(d => d.DataSourceId == dsId);
             Assert.IsTrue(ds.IsLocked);
         }
+
+        var client = new Mock<DurableTaskClient>("test");
+        client.Setup(c => c.ScheduleNewOrchestrationInstanceAsync(
+            It.IsAny<TaskName>(),
+            It.IsAny<object?>(),
+            It.IsAny<StartOrchestrationOptions?>(),
+            It.IsAny<CancellationToken>())).ReturnsAsync("instance");
 
         var stopReq = new HttpRequestDataBuilder()
             .WithUrl($"http://localhost/api/dukascopy-job/{id}/disable")

--- a/api/Stratrack.Api/Domain/Dukascopy/DukascopyJobAggregate.cs
+++ b/api/Stratrack.Api/Domain/Dukascopy/DukascopyJobAggregate.cs
@@ -19,10 +19,10 @@ public class DukascopyJobAggregate(DukascopyJobId id) : AggregateRoot<DukascopyJ
     public bool IsEnabled { get; private set; }
     public DateTimeOffset? LastExecutedAt { get; private set; }
     public bool IsRunning { get; private set; }
-    public DateTimeOffset? LastProcessStartedAt { get; private set; }
-    public DateTimeOffset? LastProcessFinishedAt { get; private set; }
-    public bool? LastProcessSucceeded { get; private set; }
-    public string? LastProcessError { get; private set; }
+    public DateTimeOffset? LastExecutionStartedAt { get; private set; }
+    public DateTimeOffset? LastExecutionFinishedAt { get; private set; }
+    public bool? LastExecutionSucceeded { get; private set; }
+    public string? LastExecutionError { get; private set; }
     public Guid? CurrentExecutionId { get; private set; }
 
     public void Create(string symbol, DateTimeOffset startTime)
@@ -133,16 +133,16 @@ public class DukascopyJobAggregate(DukascopyJobId id) : AggregateRoot<DukascopyJ
     public void Apply(DukascopyJobExecutionStartedEvent aggregateEvent)
     {
         IsRunning = true;
-        LastProcessStartedAt = aggregateEvent.StartedAt;
+        LastExecutionStartedAt = aggregateEvent.StartedAt;
         CurrentExecutionId = aggregateEvent.ExecutionId;
     }
 
     public void Apply(DukascopyJobExecutionFinishedEvent aggregateEvent)
     {
         IsRunning = false;
-        LastProcessFinishedAt = aggregateEvent.FinishedAt;
-        LastProcessSucceeded = aggregateEvent.IsSuccess;
-        LastProcessError = aggregateEvent.ErrorMessage;
+        LastExecutionFinishedAt = aggregateEvent.FinishedAt;
+        LastExecutionSucceeded = aggregateEvent.IsSuccess;
+        LastExecutionError = aggregateEvent.ErrorMessage;
         CurrentExecutionId = null;
     }
 }

--- a/api/Stratrack.Api/Domain/Dukascopy/DukascopyJobReadModel.cs
+++ b/api/Stratrack.Api/Domain/Dukascopy/DukascopyJobReadModel.cs
@@ -22,10 +22,10 @@ public class DukascopyJobReadModel : IReadModel,
     [System.ComponentModel.DataAnnotations.Schema.Column("IsEnabled")]
     public bool IsEnabled { get; set; }
     public bool IsRunning { get; set; }
-    public DateTimeOffset? LastProcessStartedAt { get; set; }
-    public DateTimeOffset? LastProcessFinishedAt { get; set; }
-    public bool? LastProcessSucceeded { get; set; }
-    public string? LastProcessError { get; set; }
+    public DateTimeOffset? LastExecutionStartedAt { get; set; }
+    public DateTimeOffset? LastExecutionFinishedAt { get; set; }
+    public bool? LastExecutionSucceeded { get; set; }
+    public string? LastExecutionError { get; set; }
     public DateTimeOffset UpdatedAt { get; private set; }
 
     public Task ApplyAsync(IReadModelContext context, IDomainEvent<DukascopyJobAggregate, DukascopyJobId, DukascopyJobCreatedEvent> domainEvent, CancellationToken cancellationToken)
@@ -83,7 +83,7 @@ public class DukascopyJobReadModel : IReadModel,
         Id = context.ReadModelId;
         JobId = domainEvent.AggregateIdentity.GetGuid();
         IsRunning = true;
-        LastProcessStartedAt = domainEvent.AggregateEvent.StartedAt;
+        LastExecutionStartedAt = domainEvent.AggregateEvent.StartedAt;
         UpdatedAt = domainEvent.Timestamp;
         return Task.CompletedTask;
     }
@@ -93,9 +93,9 @@ public class DukascopyJobReadModel : IReadModel,
         Id = context.ReadModelId;
         JobId = domainEvent.AggregateIdentity.GetGuid();
         IsRunning = false;
-        LastProcessFinishedAt = domainEvent.AggregateEvent.FinishedAt;
-        LastProcessSucceeded = domainEvent.AggregateEvent.IsSuccess;
-        LastProcessError = domainEvent.AggregateEvent.ErrorMessage;
+        LastExecutionFinishedAt = domainEvent.AggregateEvent.FinishedAt;
+        LastExecutionSucceeded = domainEvent.AggregateEvent.IsSuccess;
+        LastExecutionError = domainEvent.AggregateEvent.ErrorMessage;
         UpdatedAt = domainEvent.Timestamp;
         return Task.CompletedTask;
     }

--- a/api/Stratrack.Api/Domain/Migrations/20250709161716_InitialCreate.Designer.cs
+++ b/api/Stratrack.Api/Domain/Migrations/20250709161716_InitialCreate.Designer.cs
@@ -240,16 +240,16 @@ namespace Stratrack.Api.Domain.Migrations
                     b.Property<Guid>("JobId")
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<string>("LastProcessError")
+                    b.Property<string>("LastExecutionError")
                         .HasColumnType("nvarchar(max)");
 
-                    b.Property<DateTimeOffset?>("LastProcessFinishedAt")
+                    b.Property<DateTimeOffset?>("LastExecutionFinishedAt")
                         .HasColumnType("datetimeoffset");
 
-                    b.Property<DateTimeOffset?>("LastProcessStartedAt")
+                    b.Property<DateTimeOffset?>("LastExecutionStartedAt")
                         .HasColumnType("datetimeoffset");
 
-                    b.Property<bool?>("LastProcessSucceeded")
+                    b.Property<bool?>("LastExecutionSucceeded")
                         .HasColumnType("bit");
 
                     b.Property<DateTimeOffset>("StartTime")

--- a/api/Stratrack.Api/Domain/Migrations/20250709161716_InitialCreate.cs
+++ b/api/Stratrack.Api/Domain/Migrations/20250709161716_InitialCreate.cs
@@ -91,10 +91,10 @@ namespace Stratrack.Api.Domain.Migrations
                     IsDeleted = table.Column<bool>(type: "bit", nullable: false),
                     IsEnabled = table.Column<bool>(type: "bit", nullable: false),
                     IsRunning = table.Column<bool>(type: "bit", nullable: false),
-                    LastProcessStartedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
-                    LastProcessFinishedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
-                    LastProcessSucceeded = table.Column<bool>(type: "bit", nullable: true),
-                    LastProcessError = table.Column<string>(type: "nvarchar(max)", nullable: true),
+                    LastExecutionStartedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    LastExecutionFinishedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: true),
+                    LastExecutionSucceeded = table.Column<bool>(type: "bit", nullable: true),
+                    LastExecutionError = table.Column<string>(type: "nvarchar(max)", nullable: true),
                     UpdatedAt = table.Column<DateTimeOffset>(type: "datetimeoffset", nullable: false)
                 },
                 constraints: table =>

--- a/api/Stratrack.Api/Domain/Migrations/StratrackDbContextModelSnapshot.cs
+++ b/api/Stratrack.Api/Domain/Migrations/StratrackDbContextModelSnapshot.cs
@@ -237,16 +237,16 @@ namespace Stratrack.Api.Domain.Migrations
                     b.Property<Guid>("JobId")
                         .HasColumnType("uniqueidentifier");
 
-                    b.Property<string>("LastProcessError")
+                    b.Property<string>("LastExecutionError")
                         .HasColumnType("nvarchar(max)");
 
-                    b.Property<DateTimeOffset?>("LastProcessFinishedAt")
+                    b.Property<DateTimeOffset?>("LastExecutionFinishedAt")
                         .HasColumnType("datetimeoffset");
 
-                    b.Property<DateTimeOffset?>("LastProcessStartedAt")
+                    b.Property<DateTimeOffset?>("LastExecutionStartedAt")
                         .HasColumnType("datetimeoffset");
 
-                    b.Property<bool?>("LastProcessSucceeded")
+                    b.Property<bool?>("LastExecutionSucceeded")
                         .HasColumnType("bit");
 
                     b.Property<DateTimeOffset>("StartTime")

--- a/api/Stratrack.Api/Models/DukascopyJobSummary.cs
+++ b/api/Stratrack.Api/Models/DukascopyJobSummary.cs
@@ -8,9 +8,9 @@ public class DukascopyJobSummary
     public DateTimeOffset StartTime { get; set; }
     public bool IsEnabled { get; set; }
     public bool IsRunning { get; set; }
-    public DateTimeOffset? LastProcessStartedAt { get; set; }
-    public DateTimeOffset? LastProcessFinishedAt { get; set; }
-    public bool? LastProcessSucceeded { get; set; }
-    public string? LastProcessError { get; set; }
+    public DateTimeOffset? LastExecutionStartedAt { get; set; }
+    public DateTimeOffset? LastExecutionFinishedAt { get; set; }
+    public bool? LastExecutionSucceeded { get; set; }
+    public string? LastExecutionError { get; set; }
     public DateTimeOffset UpdatedAt { get; set; }
 }


### PR DESCRIPTION
## Summary
- rename LastProcess fields to LastExecution
- stop orchestration start in EnableDukascopyJob
- update README for new enable behavior

## Testing
- `dotnet test api/stratrack-backend.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686e9b83a4b48320860c3ab4dbe73c54