### PR TITLE
Add job execution control

### DIFF
--- a/api/Stratrack.Api/Domain/Dukascopy/Commands/DukascopyJobExecutionInterruptCommand.cs
+++ b/api/Stratrack.Api/Domain/Dukascopy/Commands/DukascopyJobExecutionInterruptCommand.cs
@@ -1,0 +1,9 @@
+using EventFlow.Commands;
+
+namespace Stratrack.Api.Domain.Dukascopy.Commands;
+
+public class DukascopyJobExecutionInterruptCommand(DukascopyJobId aggregateId) : Command<DukascopyJobAggregate, DukascopyJobId>(aggregateId)
+{
+    public Guid ExecutionId { get; set; }
+    public string? ErrorMessage { get; set; }
+}

--- a/api/Stratrack.Api/Domain/Dukascopy/Commands/DukascopyJobExecutionInterruptCommandHandler.cs
+++ b/api/Stratrack.Api/Domain/Dukascopy/Commands/DukascopyJobExecutionInterruptCommandHandler.cs
@@ -1,0 +1,12 @@
+using EventFlow.Commands;
+
+namespace Stratrack.Api.Domain.Dukascopy.Commands;
+
+public class DukascopyJobExecutionInterruptCommandHandler : CommandHandler<DukascopyJobAggregate, DukascopyJobId, DukascopyJobExecutionInterruptCommand>
+{
+    public override Task ExecuteAsync(DukascopyJobAggregate aggregate, DukascopyJobExecutionInterruptCommand command, CancellationToken cancellationToken)
+    {
+        aggregate.Interrupt(command.ExecutionId, command.ErrorMessage);
+        return Task.CompletedTask;
+    }
+}

--- a/api/Stratrack.Api/Domain/Dukascopy/Commands/DukascopyJobExecutionInterruptRequestCommand.cs
+++ b/api/Stratrack.Api/Domain/Dukascopy/Commands/DukascopyJobExecutionInterruptRequestCommand.cs
@@ -1,0 +1,7 @@
+using EventFlow.Commands;
+
+namespace Stratrack.Api.Domain.Dukascopy.Commands;
+
+public class DukascopyJobExecutionInterruptRequestCommand(DukascopyJobId aggregateId) : Command<DukascopyJobAggregate, DukascopyJobId>(aggregateId)
+{
+}

--- a/api/Stratrack.Api/Domain/Dukascopy/Commands/DukascopyJobExecutionInterruptRequestCommandHandler.cs
+++ b/api/Stratrack.Api/Domain/Dukascopy/Commands/DukascopyJobExecutionInterruptRequestCommandHandler.cs
@@ -1,0 +1,12 @@
+using EventFlow.Commands;
+
+namespace Stratrack.Api.Domain.Dukascopy.Commands;
+
+public class DukascopyJobExecutionInterruptRequestCommandHandler : CommandHandler<DukascopyJobAggregate, DukascopyJobId, DukascopyJobExecutionInterruptRequestCommand>
+{
+    public override Task ExecuteAsync(DukascopyJobAggregate aggregate, DukascopyJobExecutionInterruptRequestCommand command, CancellationToken cancellationToken)
+    {
+        aggregate.RequestInterrupt();
+        return Task.CompletedTask;
+    }
+}

--- a/api/Stratrack.Api/Domain/Dukascopy/DukascopyJobExecutionReadModel.cs
+++ b/api/Stratrack.Api/Domain/Dukascopy/DukascopyJobExecutionReadModel.cs
@@ -7,7 +7,8 @@ namespace Stratrack.Api.Domain.Dukascopy;
 
 public class DukascopyJobExecutionReadModel : IReadModel,
     IAmReadModelFor<DukascopyJobAggregate, DukascopyJobId, DukascopyJobExecutionStartedEvent>,
-    IAmReadModelFor<DukascopyJobAggregate, DukascopyJobId, DukascopyJobExecutionFinishedEvent>
+    IAmReadModelFor<DukascopyJobAggregate, DukascopyJobId, DukascopyJobExecutionFinishedEvent>,
+    IAmReadModelFor<DukascopyJobAggregate, DukascopyJobId, DukascopyJobExecutionInterruptedEvent>
 {
     [Key]
     public Guid ExecutionId { get; set; }
@@ -31,6 +32,16 @@ public class DukascopyJobExecutionReadModel : IReadModel,
         JobId = domainEvent.AggregateIdentity.GetGuid();
         FinishedAt = domainEvent.AggregateEvent.FinishedAt;
         IsSuccess = domainEvent.AggregateEvent.IsSuccess;
+        ErrorMessage = domainEvent.AggregateEvent.ErrorMessage;
+        return Task.CompletedTask;
+    }
+
+    public Task ApplyAsync(IReadModelContext context, IDomainEvent<DukascopyJobAggregate, DukascopyJobId, DukascopyJobExecutionInterruptedEvent> domainEvent, CancellationToken cancellationToken)
+    {
+        ExecutionId = domainEvent.AggregateEvent.ExecutionId;
+        JobId = domainEvent.AggregateIdentity.GetGuid();
+        FinishedAt = domainEvent.Timestamp;
+        IsSuccess = false;
         ErrorMessage = domainEvent.AggregateEvent.ErrorMessage;
         return Task.CompletedTask;
     }

--- a/api/Stratrack.Api/Domain/Dukascopy/Events/DukascopyJobExecutionInterruptRequestedEvent.cs
+++ b/api/Stratrack.Api/Domain/Dukascopy/Events/DukascopyJobExecutionInterruptRequestedEvent.cs
@@ -1,0 +1,9 @@
+using EventFlow.Aggregates;
+using EventFlow.EventStores;
+
+namespace Stratrack.Api.Domain.Dukascopy.Events;
+
+[EventVersion("DukascopyJobExecutionInterruptRequested", 1)]
+public class DukascopyJobExecutionInterruptRequestedEvent : AggregateEvent<DukascopyJobAggregate, DukascopyJobId>
+{
+}

--- a/api/Stratrack.Api/Domain/Dukascopy/Events/DukascopyJobExecutionInterruptedEvent.cs
+++ b/api/Stratrack.Api/Domain/Dukascopy/Events/DukascopyJobExecutionInterruptedEvent.cs
@@ -1,0 +1,11 @@
+using EventFlow.Aggregates;
+using EventFlow.EventStores;
+
+namespace Stratrack.Api.Domain.Dukascopy.Events;
+
+[EventVersion("DukascopyJobExecutionInterrupted", 1)]
+public class DukascopyJobExecutionInterruptedEvent(Guid executionId, string? errorMessage) : AggregateEvent<DukascopyJobAggregate, DukascopyJobId>
+{
+    public Guid ExecutionId { get; } = executionId;
+    public string? ErrorMessage { get; } = errorMessage;
+}

--- a/api/Stratrack.Api/Domain/Migrations/20250709173555_AddInterruptFields.Designer.cs
+++ b/api/Stratrack.Api/Domain/Migrations/20250709173555_AddInterruptFields.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Stratrack.Api.Domain;
 
@@ -11,9 +12,11 @@ using Stratrack.Api.Domain;
 namespace Stratrack.Api.Domain.Migrations
 {
     [DbContext(typeof(StratrackDbContext))]
-    partial class StratrackDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250709173555_AddInterruptFields")]
+    partial class AddInterruptFields
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
@@ -220,9 +223,6 @@ namespace Stratrack.Api.Domain.Migrations
                 {
                     b.Property<string>("Id")
                         .HasColumnType("nvarchar(450)");
-
-                    b.Property<Guid?>("CurrentExecutionId")
-                        .HasColumnType("uniqueidentifier");
 
                     b.Property<Guid>("DataSourceId")
                         .HasColumnType("uniqueidentifier");

--- a/api/Stratrack.Api/Domain/Migrations/20250709173555_AddInterruptFields.cs
+++ b/api/Stratrack.Api/Domain/Migrations/20250709173555_AddInterruptFields.cs
@@ -1,0 +1,29 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Stratrack.Api.Domain.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInterruptFields : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "InterruptRequested",
+                table: "DukascopyJobs",
+                type: "bit",
+                nullable: false,
+                defaultValue: false);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "InterruptRequested",
+                table: "DukascopyJobs");
+        }
+    }
+}

--- a/api/Stratrack.Api/Domain/Migrations/20250709173946_AddCurrentExecution.Designer.cs
+++ b/api/Stratrack.Api/Domain/Migrations/20250709173946_AddCurrentExecution.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Stratrack.Api.Domain;
 
@@ -11,9 +12,11 @@ using Stratrack.Api.Domain;
 namespace Stratrack.Api.Domain.Migrations
 {
     [DbContext(typeof(StratrackDbContext))]
-    partial class StratrackDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250709173946_AddCurrentExecution")]
+    partial class AddCurrentExecution
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/Stratrack.Api/Domain/Migrations/20250709173946_AddCurrentExecution.cs
+++ b/api/Stratrack.Api/Domain/Migrations/20250709173946_AddCurrentExecution.cs
@@ -1,0 +1,29 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Stratrack.Api.Domain.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCurrentExecution : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "CurrentExecutionId",
+                table: "DukascopyJobs",
+                type: "uniqueidentifier",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "CurrentExecutionId",
+                table: "DukascopyJobs");
+        }
+    }
+}

--- a/api/Stratrack.Api/Domain/ServiceCollectionExtension.cs
+++ b/api/Stratrack.Api/Domain/ServiceCollectionExtension.cs
@@ -44,7 +44,9 @@ public static class ServiceCollectionExtension
                 typeof(DukascopyJobDeleteCommand),
                 typeof(DukascopyJobExecutedCommand),
                 typeof(DukascopyJobExecutionStartCommand),
-                typeof(DukascopyJobExecutionFinishCommand)
+                typeof(DukascopyJobExecutionFinishCommand),
+                typeof(DukascopyJobExecutionInterruptRequestCommand),
+                typeof(DukascopyJobExecutionInterruptCommand)
             ).AddCommandHandlers(
                 typeof(StrategyCreateCommandHandler),
                 typeof(StrategyUpdateCommandHandler),
@@ -63,7 +65,9 @@ public static class ServiceCollectionExtension
                 typeof(DukascopyJobDeleteCommandHandler),
                 typeof(DukascopyJobExecutedCommandHandler),
                 typeof(DukascopyJobExecutionStartCommandHandler),
-                typeof(DukascopyJobExecutionFinishCommandHandler)
+                typeof(DukascopyJobExecutionFinishCommandHandler),
+                typeof(DukascopyJobExecutionInterruptRequestCommandHandler),
+                typeof(DukascopyJobExecutionInterruptCommandHandler)
             ).AddEvents(
                 typeof(StrategyCreatedEvent),
                 typeof(StrategyUpdatedEvent),
@@ -83,7 +87,9 @@ public static class ServiceCollectionExtension
                 typeof(DukascopyJobDeletedEvent),
                 typeof(DukascopyJobExecutedEvent),
                 typeof(DukascopyJobExecutionStartedEvent),
-                typeof(DukascopyJobExecutionFinishedEvent)
+                typeof(DukascopyJobExecutionFinishedEvent),
+                typeof(DukascopyJobExecutionInterruptRequestedEvent),
+                typeof(DukascopyJobExecutionInterruptedEvent)
             );
 
             ef.ConfigureEntityFramework(EntityFrameworkConfiguration.New);

--- a/api/Stratrack.Api/Functions/DukascopyJobFunctions.cs
+++ b/api/Stratrack.Api/Functions/DukascopyJobFunctions.cs
@@ -154,6 +154,7 @@ public class DukascopyJobFunctions(
                 StartTime = j.StartTime,
                 IsEnabled = j.IsEnabled,
                 IsRunning = j.IsRunning,
+                InterruptRequested = j.InterruptRequested,
                 LastExecutionStartedAt = j.LastExecutionStartedAt,
                 LastExecutionFinishedAt = j.LastExecutionFinishedAt,
                 LastExecutionSucceeded = j.LastExecutionSucceeded,

--- a/api/Stratrack.Api/Models/DukascopyJobSummary.cs
+++ b/api/Stratrack.Api/Models/DukascopyJobSummary.cs
@@ -8,6 +8,7 @@ public class DukascopyJobSummary
     public DateTimeOffset StartTime { get; set; }
     public bool IsEnabled { get; set; }
     public bool IsRunning { get; set; }
+    public bool InterruptRequested { get; set; }
     public DateTimeOffset? LastExecutionStartedAt { get; set; }
     public DateTimeOffset? LastExecutionFinishedAt { get; set; }
     public bool? LastExecutionSucceeded { get; set; }

--- a/frontend/src/api/dukascopyJobs.ts
+++ b/frontend/src/api/dukascopyJobs.ts
@@ -16,6 +16,7 @@ export type DukascopyJobSummary = {
   startTime: string;
   isEnabled: boolean;
   isRunning: boolean;
+  interruptRequested?: boolean;
   lastProcessStartedAt?: string;
   lastProcessFinishedAt?: string;
   lastProcessSucceeded?: boolean;
@@ -74,6 +75,26 @@ export async function startDukascopyJobExecution(id: string) {
   });
   if (!res.ok) {
     throw new Error(`Failed to start dukascopy job execution: ${res.status}`);
+  }
+}
+
+export async function requestInterruptDukascopyJob(id: string) {
+  const res = await fetch(`${API_BASE_URL}/api/dukascopy-job/${id}/interrupt-request`, {
+    method: "POST",
+    headers: { "x-functions-key": API_KEY },
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to request interrupt: ${res.status}`);
+  }
+}
+
+export async function interruptDukascopyJob(id: string) {
+  const res = await fetch(`${API_BASE_URL}/api/dukascopy-job/${id}/interrupt`, {
+    method: "POST",
+    headers: { "x-functions-key": API_KEY },
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to interrupt job: ${res.status}`);
   }
 }
 

--- a/frontend/src/routes/settings/DukascopyJobCard.stories.tsx
+++ b/frontend/src/routes/settings/DukascopyJobCard.stories.tsx
@@ -15,6 +15,9 @@ const meta = {
     disabled: false,
     onDateChange: fn(),
     onToggle: fn(),
+    onRun: fn(),
+    onInterruptRequest: fn(),
+    onInterrupt: fn(),
   },
 } satisfies Meta<typeof DukascopyJobCard>;
 

--- a/frontend/src/routes/settings/DukascopyJobCard.tsx
+++ b/frontend/src/routes/settings/DukascopyJobCard.tsx
@@ -5,6 +5,7 @@ export type JobState = {
   start: string;
   enabled: boolean;
   running?: boolean;
+  interruptRequested?: boolean;
   lastStarted?: string;
   lastFinished?: string;
   lastSucceeded?: boolean;
@@ -20,9 +21,21 @@ type Props = {
   disabled: boolean;
   onDateChange: (pair: string, value: string) => void;
   onToggle: (pair: string) => void;
+  onRun: (pair: string) => void;
+  onInterruptRequest: (pair: string) => void;
+  onInterrupt: (pair: string) => void;
 };
 
-const DukascopyJobCard = ({ pair, job, disabled, onDateChange, onToggle }: Props) => {
+const DukascopyJobCard = ({
+  pair,
+  job,
+  disabled,
+  onDateChange,
+  onToggle,
+  onRun,
+  onInterruptRequest,
+  onInterrupt,
+}: Props) => {
   const isLoading = !job.loaded;
   return (
     <div className="rounded-xl border p-4 shadow space-y-2">
@@ -35,9 +48,26 @@ const DukascopyJobCard = ({ pair, job, disabled, onDateChange, onToggle }: Props
         fullWidth
         disabled={isLoading}
       />
-      <Button size="sm" onClick={() => onToggle(pair)} disabled={disabled}>
-        {job.enabled ? "無効化" : "有効化"}
-      </Button>
+      <div className="flex gap-2">
+        <Button size="sm" onClick={() => onToggle(pair)} disabled={disabled}>
+          {job.enabled ? "無効化" : "有効化"}
+        </Button>
+        {job.enabled && !job.running && (
+          <Button size="sm" onClick={() => onRun(pair)} disabled={disabled}>
+            実行
+          </Button>
+        )}
+        {job.running && !job.interruptRequested && (
+          <Button size="sm" onClick={() => onInterruptRequest(pair)} disabled={disabled}>
+            中断依頼
+          </Button>
+        )}
+        {job.running && job.interruptRequested && (
+          <Button size="sm" onClick={() => onInterrupt(pair)} disabled={disabled}>
+            中断
+          </Button>
+        )}
+      </div>
       <p className="text-sm">
         現在のステータス: {job.enabled ? "有効" : "無効"}
         {job.running ? " (処理中)" : ""}


### PR DESCRIPTION
## Summary
- add interrupt request & interrupt events, commands, and read model fields
- implement APIs to start, request interrupt, and interrupt Dukascopy jobs
- expose interrupt status to frontend and add controls to run or interrupt jobs
- track current execution and include migrations
- update storybook stories and API definitions

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run build`
- `dotnet test api/stratrack-backend.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686ea577fb8883209eb329194e7b11a4