### PR TITLE
Revert ExecutionReadModel ID type

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,7 +39,8 @@ Python の FastAPI プロジェクトで当初はこの形でリリースする�
 - Domain フォルダでは Aggregate クラスをモジュール直下に置き、`Commands` `Events` `Queries` の各サブフォルダを設ける構成を標準とします。例として `Domain/Dukascopy/DukascopyJobAggregate.cs` とその周辺に `Commands` `Events` `Queries` フォルダを配置します。
 - Entity Framework の `DbContext` を直接扱わず、読み取りは `IQueryProcessor` を介したクエリハンドラー経由で行ってください。
 - CommandHandler 内で ReadModel やデータベースを参照する処理は避け、Aggregate の状態のみを利用して判断してください。
-- ID は基本的に `Guid` で保持し、ReadModel やイベント間で型が変わらないよう注意してください。文字列へ変換する場合は必要最小限にとどめます。
+- ReadModel の ID は基本的に `Guid` で保持します。EventFlow の `Identity` として利用する際はプレフィックス付きの文字列に変換されるため、
+ その GUID を他のエンティティの ID として再利用しないよう注意してください。
 
 ## データベースマイグレーション
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,7 @@ Python の FastAPI プロジェクトで当初はこの形でリリースする�
 - Domain フォルダでは Aggregate クラスをモジュール直下に置き、`Commands` `Events` `Queries` の各サブフォルダを設ける構成を標準とします。例として `Domain/Dukascopy/DukascopyJobAggregate.cs` とその周辺に `Commands` `Events` `Queries` フォルダを配置します。
 - Entity Framework の `DbContext` を直接扱わず、読み取りは `IQueryProcessor` を介したクエリハンドラー経由で行ってください。
 - CommandHandler 内で ReadModel やデータベースを参照する処理は避け、Aggregate の状態のみを利用して判断してください。
+- ID は基本的に `Guid` で保持し、ReadModel やイベント間で型が変わらないよう注意してください。文字列へ変換する場合は必要最小限にとどめます。
 
 ## データベースマイグレーション
 

--- a/api/Stratrack.Api/Domain/Dukascopy/DukascopyJobExecutionReadModel.cs
+++ b/api/Stratrack.Api/Domain/Dukascopy/DukascopyJobExecutionReadModel.cs
@@ -10,8 +10,9 @@ public class DukascopyJobExecutionReadModel : IReadModel,
     IAmReadModelFor<DukascopyJobAggregate, DukascopyJobId, DukascopyJobExecutionFinishedEvent>,
     IAmReadModelFor<DukascopyJobAggregate, DukascopyJobId, DukascopyJobExecutionInterruptedEvent>
 {
-    [Key]
-    public string ExecutionId { get; set; } = "";
+[Key]
+public string Id { get; set; } = string.Empty;
+public Guid ExecutionId { get; set; }
     public Guid JobId { get; set; }
     public DateTimeOffset StartedAt { get; set; }
     public DateTimeOffset? FinishedAt { get; set; }
@@ -20,7 +21,8 @@ public class DukascopyJobExecutionReadModel : IReadModel,
 
     public Task ApplyAsync(IReadModelContext context, IDomainEvent<DukascopyJobAggregate, DukascopyJobId, DukascopyJobExecutionStartedEvent> domainEvent, CancellationToken cancellationToken)
     {
-        ExecutionId = domainEvent.AggregateEvent.ExecutionId.ToString();
+        Id = context.ReadModelId;
+        ExecutionId = domainEvent.AggregateEvent.ExecutionId;
         JobId = domainEvent.AggregateIdentity.GetGuid();
         StartedAt = domainEvent.AggregateEvent.StartedAt;
         return Task.CompletedTask;
@@ -28,7 +30,8 @@ public class DukascopyJobExecutionReadModel : IReadModel,
 
     public Task ApplyAsync(IReadModelContext context, IDomainEvent<DukascopyJobAggregate, DukascopyJobId, DukascopyJobExecutionFinishedEvent> domainEvent, CancellationToken cancellationToken)
     {
-        ExecutionId = domainEvent.AggregateEvent.ExecutionId.ToString();
+        Id = context.ReadModelId;
+        ExecutionId = domainEvent.AggregateEvent.ExecutionId;
         JobId = domainEvent.AggregateIdentity.GetGuid();
         FinishedAt = domainEvent.AggregateEvent.FinishedAt;
         IsSuccess = domainEvent.AggregateEvent.IsSuccess;
@@ -38,7 +41,8 @@ public class DukascopyJobExecutionReadModel : IReadModel,
 
     public Task ApplyAsync(IReadModelContext context, IDomainEvent<DukascopyJobAggregate, DukascopyJobId, DukascopyJobExecutionInterruptedEvent> domainEvent, CancellationToken cancellationToken)
     {
-        ExecutionId = domainEvent.AggregateEvent.ExecutionId.ToString();
+        Id = context.ReadModelId;
+        ExecutionId = domainEvent.AggregateEvent.ExecutionId;
         JobId = domainEvent.AggregateIdentity.GetGuid();
         FinishedAt = domainEvent.Timestamp;
         IsSuccess = false;

--- a/api/Stratrack.Api/Domain/Migrations/20250709200332_ChangeExecutionReadModelKey.Designer.cs
+++ b/api/Stratrack.Api/Domain/Migrations/20250709200332_ChangeExecutionReadModelKey.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Stratrack.Api.Domain;
 
@@ -11,9 +12,11 @@ using Stratrack.Api.Domain;
 namespace Stratrack.Api.Domain.Migrations
 {
     [DbContext(typeof(StratrackDbContext))]
-    partial class StratrackDbContextModelSnapshot : ModelSnapshot
+    [Migration("20250709200332_ChangeExecutionReadModelKey")]
+    partial class ChangeExecutionReadModelKey
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/api/Stratrack.Api/Domain/Migrations/20250709200332_ChangeExecutionReadModelKey.cs
+++ b/api/Stratrack.Api/Domain/Migrations/20250709200332_ChangeExecutionReadModelKey.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Stratrack.Api.Domain.Migrations
+{
+    /// <inheritdoc />
+    public partial class ChangeExecutionReadModelKey : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_DukascopyJobExecutions",
+                table: "DukascopyJobExecutions");
+
+            migrationBuilder.AddColumn<string>(
+                name: "Id",
+                table: "DukascopyJobExecutions",
+                type: "nvarchar(450)",
+                nullable: false,
+                defaultValue: "");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_DukascopyJobExecutions",
+                table: "DukascopyJobExecutions",
+                column: "Id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropPrimaryKey(
+                name: "PK_DukascopyJobExecutions",
+                table: "DukascopyJobExecutions");
+
+            migrationBuilder.DropColumn(
+                name: "Id",
+                table: "DukascopyJobExecutions");
+
+            migrationBuilder.AddPrimaryKey(
+                name: "PK_DukascopyJobExecutions",
+                table: "DukascopyJobExecutions",
+                column: "ExecutionId");
+        }
+    }
+}

--- a/api/Stratrack.Api/Domain/StratrackDbContext.cs
+++ b/api/Stratrack.Api/Domain/StratrackDbContext.cs
@@ -42,7 +42,7 @@ public class StratrackDbContext : DbContext
         });
         modelBuilder.Entity<DukascopyJobExecutionReadModel>(entity =>
         {
-            entity.HasKey(m => m.ExecutionId);
+            entity.HasKey(m => m.Id);
         });
         modelBuilder.Entity<DukascopyJobStepReadModel>(entity =>
         {


### PR DESCRIPTION
## Summary
- document that IDs should stay Guid-based
- revert execution read model to use Guid ExecutionId and add string key
- update EF mapping and add migration

## Testing
- `dotnet test api/stratrack-backend.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_686ec89995508320abe2fd3d6f49e6da