### PR TITLE
Implement OHLC aggregation in data stream API

### DIFF
--- a/api/Stratrack.Api.Tests/DataStreamFunctionsTests.cs
+++ b/api/Stratrack.Api.Tests/DataStreamFunctionsTests.cs
@@ -50,7 +50,7 @@ public class DataStreamFunctionsTests
     }
 
     [TestMethod]
-    public async Task GetDataStream_ReturnsChunkData()
+    public async Task GetDataStream_ReturnsOhlcData()
     {
         using var provider = CreateProvider();
         var dsId = await CreateDataSourceAsync(provider);
@@ -70,12 +70,12 @@ public class DataStreamFunctionsTests
 
         var streamFunc = provider.GetRequiredService<DataStreamFunctions>();
         var req = new HttpRequestDataBuilder()
-            .WithUrl($"http://localhost/api/data-sources/{dsId}/stream?startTime=2024-01-01T00:00:00Z&endTime=2024-01-01T01:00:00Z")
+            .WithUrl($"http://localhost/api/data-sources/{dsId}/stream?startTime=2024-01-01T00:00:00Z&endTime=2024-01-01T01:00:00Z&format=ohlc&timeframe=5m")
             .WithMethod(HttpMethod.Get)
             .Build();
         var res = await streamFunc.GetDataStream(req, dsId, CancellationToken.None);
         Assert.AreEqual(HttpStatusCode.OK, res.StatusCode);
         var body = await res.ReadAsStringAsync();
-        Assert.AreEqual("time,bid,ask\n", body);
+        Assert.IsTrue(body.StartsWith("time,open,high,low,close"));
     }
 }

--- a/api/Stratrack.Api/Functions/DataStreamFunctions.cs
+++ b/api/Stratrack.Api/Functions/DataStreamFunctions.cs
@@ -11,6 +11,8 @@ using EventFlow.Queries;
 using System.Net;
 using System.Linq;
 using System;
+using System.Collections.Generic;
+using System.Text;
 
 namespace Stratrack.Api.Functions;
 
@@ -29,6 +31,8 @@ public class DataStreamFunctions(
     [OpenApiParameter(name: "dataSourceId", In = ParameterLocation.Path, Required = true, Type = typeof(string))]
     [OpenApiParameter(name: "startTime", In = ParameterLocation.Query, Required = true, Type = typeof(string))]
     [OpenApiParameter(name: "endTime", In = ParameterLocation.Query, Required = true, Type = typeof(string))]
+    [OpenApiParameter(name: "format", In = ParameterLocation.Query, Required = false, Type = typeof(string))]
+    [OpenApiParameter(name: "timeframe", In = ParameterLocation.Query, Required = false, Type = typeof(string))]
     [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.OK, Description = "Ok")]
     [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.NotFound, Description = "Not found")]
     [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.UnprocessableEntity, Description = "Unprocessable entity")]
@@ -40,6 +44,8 @@ public class DataStreamFunctions(
         var query = System.Web.HttpUtility.ParseQueryString(req.Url.Query);
         var startStr = query.Get("startTime");
         var endStr = query.Get("endTime");
+        var formatStr = query.Get("format")?.ToLower();
+        var timeframeStr = query.Get("timeframe");
         if (startStr == null || endStr == null)
         {
             return req.CreateResponse(HttpStatusCode.UnprocessableEntity);
@@ -71,13 +77,110 @@ public class DataStreamFunctions(
             .OrderBy(c => c.StartTime)
             .ToList();
 
-        var response = req.CreateResponse(HttpStatusCode.OK);
-        response.Headers.Add("Content-Type", "text/plain");
+        var format = formatStr ?? (dataSource.Format == DataFormat.Tick ? "tick" : "ohlc");
+        var timeframe = timeframeStr ?? dataSource.Timeframe;
+
+        var lines = new List<string>();
         foreach (var chunk in target)
         {
             var data = await _blobStorage.GetAsync(chunk.BlobId, token).ConfigureAwait(false);
-            await response.Body.WriteAsync(data, token).ConfigureAwait(false);
+            var text = System.Text.Encoding.UTF8.GetString(data);
+            lines.AddRange(text.Split('\n', StringSplitOptions.RemoveEmptyEntries).Skip(1));
+        }
+
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        response.Headers.Add("Content-Type", "text/plain");
+
+        if (format == "tick")
+        {
+            await response.WriteStringAsync("time,bid\n", token).ConfigureAwait(false);
+            foreach (var line in lines)
+            {
+                var parts = line.Split(',');
+                if (parts.Length < 2) continue;
+                var time = DateTimeOffset.Parse(parts[0]);
+                if (time < start || time >= end) continue;
+                await response.WriteStringAsync($"{time:o},{parts[1]}\n", token).ConfigureAwait(false);
+            }
+            return response;
+        }
+
+        int tfMinutes = ParseTimeframeMinutes(timeframe);
+        await response.WriteStringAsync("time,open,high,low,close\n", token).ConfigureAwait(false);
+        var ohlc = BuildOhlc(lines, dataSource.Format, tfMinutes, start, end);
+        foreach (var c in ohlc)
+        {
+            await response.WriteStringAsync($"{c.Time:o},{c.Open},{c.High},{c.Low},{c.Close}\n", token).ConfigureAwait(false);
         }
         return response;
+    }
+
+    private static int ParseTimeframeMinutes(string timeframe)
+    {
+        return timeframe switch
+        {
+            "1m" => 1,
+            "5m" => 5,
+            "15m" => 15,
+            "30m" => 30,
+            "1h" => 60,
+            "2h" => 120,
+            "4h" => 240,
+            "1d" => 1440,
+            _ => 0,
+        };
+    }
+
+    private static IEnumerable<(DateTimeOffset Time, decimal Open, decimal High, decimal Low, decimal Close)> BuildOhlc(IEnumerable<string> lines, DataFormat format, int tfMinutes, DateTimeOffset start, DateTimeOffset end)
+    {
+        var entries = new List<(DateTimeOffset Time, decimal Open, decimal High, decimal Low, decimal Close)>();
+        foreach (var line in lines)
+        {
+            var parts = line.Split(',');
+            if (parts.Length < 2) continue;
+            var time = DateTimeOffset.Parse(parts[0]);
+            if (time < start || time >= end) continue;
+            if (format == DataFormat.Tick)
+            {
+                var price = decimal.Parse(parts[1]);
+                entries.Add((time, price, price, price, price));
+            }
+            else
+            {
+                if (parts.Length < 5) continue;
+                var open = decimal.Parse(parts[1]);
+                var high = decimal.Parse(parts[2]);
+                var low = decimal.Parse(parts[3]);
+                var close = decimal.Parse(parts[4]);
+                entries.Add((time, open, high, low, close));
+            }
+        }
+
+        if (tfMinutes <= 0)
+        {
+            foreach (var e in entries.OrderBy(e => e.Time))
+            {
+                yield return e;
+            }
+            yield break;
+        }
+
+        var group = entries
+            .OrderBy(e => e.Time)
+            .GroupBy(e => AlignTime(e.Time, tfMinutes));
+
+        foreach (var g in group)
+        {
+            var first = g.First();
+            var last = g.Last();
+            yield return (g.Key, first.Open, g.Max(x => x.High), g.Min(x => x.Low), last.Close);
+        }
+    }
+
+    private static DateTimeOffset AlignTime(DateTimeOffset time, int minutes)
+    {
+        if (minutes <= 0) return time;
+        var ticks = time.UtcTicks - (time.UtcTicks % TimeSpan.FromMinutes(minutes).Ticks);
+        return new DateTimeOffset(ticks, TimeSpan.Zero);
     }
 }

--- a/frontend/src/api/data.ts
+++ b/frontend/src/api/data.ts
@@ -44,9 +44,12 @@ export async function uploadDataFile(dataSourceId: string, file: File) {
 export async function getDataStream(
   dataSourceId: string,
   startTime: string,
-  endTime: string
+  endTime: string,
+  format = "tick",
+  timeframe?: string
 ): Promise<string> {
-  const params = new URLSearchParams({ startTime, endTime });
+  const params = new URLSearchParams({ startTime, endTime, format });
+  if (timeframe) params.append("timeframe", timeframe);
   const res = await fetch(
     `${API_BASE_URL}/api/data-sources/${dataSourceId}/stream?${params.toString()}`,
     {

--- a/frontend/src/routes/datasources/chart.tsx
+++ b/frontend/src/routes/datasources/chart.tsx
@@ -1,56 +1,44 @@
 import { useEffect, useState, useCallback } from "react";
 import { useParams } from "react-router-dom";
-import { DataSourceDetail, getDataSource } from "../../api/datasources";
+import { getDataSource } from "../../api/datasources";
 import { getDataStream } from "../../api/data";
-import LineChart, { LinePoint } from "../../components/LineChart";
 import CandlestickChart, { Candle } from "../../components/CandlestickChart";
 
 const DataSourceChart = () => {
   const { dataSourceId } = useParams<{ dataSourceId: string }>();
   const [range, setRange] = useState<{ from: number; to: number } | null>(null);
-  const [lineData, setLineData] = useState<LinePoint[]>([]);
   const [candleData, setCandleData] = useState<Candle[]>([]);
-  const [dataSource, setDataSource] = useState<DataSourceDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const loadData = useCallback(
     async (from: string, to: string) => {
       if (!dataSourceId) return;
       try {
-        const csv = await getDataStream(dataSourceId, from, to);
+        const csv = await getDataStream(dataSourceId, from, to, "ohlc", "5m");
         const lines = csv.split(/\r?\n/).filter((l) => l && !l.startsWith("time"));
-        if (dataSource?.format === "ohlc") {
-          const candles: Candle[] = lines.map((l) => {
-            const [t, o, h, low, c] = l.split(",");
-            return {
-              date: new Date(t),
-              open: parseFloat(o),
-              high: parseFloat(h),
-              low: parseFloat(low),
-              close: parseFloat(c),
-            };
-          });
-          setCandleData(candles);
-        } else {
-          const points: LinePoint[] = lines.map((l) => {
-            const [t, bid] = l.split(",");
-            return { x: Date.parse(t), y: parseFloat(bid) };
-          });
-          setLineData(points);
-        }
+        const candles: Candle[] = lines.map((l) => {
+          const [t, o, h, low, c] = l.split(",");
+          return {
+            date: new Date(t),
+            open: parseFloat(o),
+            high: parseFloat(h),
+            low: parseFloat(low),
+            close: parseFloat(c),
+          };
+        });
+        setCandleData(candles);
         setError(null);
       } catch (e) {
         setError((e as Error).message);
       }
     },
-    [dataSourceId, dataSource]
+    [dataSourceId]
   );
 
   useEffect(() => {
     if (!dataSourceId) return;
     getDataSource(dataSourceId)
       .then(async (ds) => {
-        setDataSource(ds);
         if (ds.startTime && ds.endTime) {
           const end = new Date(ds.endTime).getTime();
           const start = ds.startTime ? new Date(ds.startTime).getTime() : end;
@@ -70,15 +58,11 @@ const DataSourceChart = () => {
     <div className="p-6 space-y-4">
       <h2 className="text-2xl font-bold">チャート表示</h2>
       {error && <p className="text-error">{error}</p>}
-      {dataSource?.format === "ohlc" ? (
-        <CandlestickChart
-          data={candleData}
-          range={range ?? undefined}
-          onRangeChange={handleRangeChange}
-        />
-      ) : (
-        <LineChart data={lineData} range={range ?? undefined} onRangeChange={handleRangeChange} />
-      )}
+      <CandlestickChart
+        data={candleData}
+        range={range ?? undefined}
+        onRangeChange={handleRangeChange}
+      />
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- allow `format` and `timeframe` parameters for the data stream API
- aggregate tick or lower timeframe data into arbitrary OHLC interval
- update frontend API client and chart to request `ohlc/5m`
- simplify chart screen to always show candlesticks
- test OHLC stream retrieval

## Testing
- `dotnet test api/stratrack-backend.sln -c Release`
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_686fac7ac5fc8320816b8b6366043e59