### PR TITLE
Implement SSE output for data stream API

### DIFF
--- a/api/Stratrack.Api.Tests/DataStreamFunctionsTests.cs
+++ b/api/Stratrack.Api.Tests/DataStreamFunctionsTests.cs
@@ -6,6 +6,7 @@ using Stratrack.Api.Infrastructure;
 using Stratrack.Api.Models;
 using Stratrack.Api.Domain.DataSources;
 using System.Net;
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 using WorkerHttpFake;
@@ -75,7 +76,8 @@ public class DataStreamFunctionsTests
             .Build();
         var res = await streamFunc.GetDataStream(req, dsId, CancellationToken.None);
         Assert.AreEqual(HttpStatusCode.OK, res.StatusCode);
+        Assert.AreEqual("text/event-stream", res.Headers.GetValues("Content-Type").First());
         var body = await res.ReadAsStringAsync();
-        Assert.IsTrue(body.StartsWith("time,open,high,low,close"));
+        Assert.IsTrue(body.StartsWith("data: time,open,high,low,close"));
     }
 }

--- a/docs/5.indexeddb-backend-flow.md
+++ b/docs/5.indexeddb-backend-flow.md
@@ -1,0 +1,26 @@
+# IndexedDB とバックエンドのデータフロー
+
+以下はチャート表示時におけるフロントエンド IndexedDB とバックエンド API の連携を、時間に着目して表したものです。
+
+```mermaid
+sequenceDiagram
+    participant Chart as ChartComponent
+    participant IDB as IndexedDB
+    participant API as DataStream API
+
+    Chart->>IDB: loadCandles(dsId, timeframe, from, to)
+    alt hit
+        IDB-->>Chart: Candle[]
+        Chart->>Chart: 描画
+    else miss
+        IDB-->>Chart: []
+        Chart->>API: GET /stream?startTime=from&endTime=to&format=ohlc&timeframe=timeframe
+        API-->>Chart: SSE "data: time,open,high,low,close"
+        Chart->>IDB: saveCandles(dsId, timeframe, candles)
+        Chart->>Chart: 描画
+    end
+```
+
+- `from` と `to` は ISO 文字列で指定され、IndexedDB では `time` (Unix ミリ秒) をキーに範囲検索します。
+- API は `Server-Sent Events` 形式で OHLC データを返し、クライアントは受信後 IndexedDB に保存します。
+- 再表示時は同一 `dataSourceId` と `timeframe` で `from` - `to` の範囲に一致するデータがあればそれを再利用します。

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -41,6 +41,7 @@
         "eslint-plugin-react-hooks": "^5.1.0",
         "eslint-plugin-react-refresh": "^0.4.19",
         "eslint-plugin-storybook": "^9.0.12",
+        "fake-indexeddb": "^6.0.1",
         "globals": "^15.15.0",
         "jsdom": "^26.1.0",
         "playwright": "^1.51.1",
@@ -3765,6 +3766,16 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fake-indexeddb": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/fake-indexeddb/-/fake-indexeddb-6.0.1.tgz",
+      "integrity": "sha512-He2AjQGHe46svIFq5+L2Nx/eHDTI1oKgoevBP+TthnjymXiKkeJQ3+ITeWey99Y5+2OaPFbI1qEsx/5RsGtWnQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/fast-deep-equal": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -14,6 +14,7 @@
         "chartjs-adapter-date-fns": "^3.0.0",
         "chartjs-chart-financial": "^0.2.1",
         "chartjs-plugin-zoom": "^2.2.0",
+        "idb": "^7.1.1",
         "react": "^19.0.0",
         "react-ace": "^14.0.1",
         "react-chartjs-2": "^5.3.0",
@@ -4135,6 +4136,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/idb": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/idb/-/idb-7.1.1.tgz",
+      "integrity": "sha512-gchesWBzyvGHRO9W8tzUWFDycow5gwjvFKfyV9FF32Y7F50yZMp7mP+T2mJIWFx49zicqyC4uefHM17o6xKIVQ==",
+      "license": "ISC"
     },
     "node_modules/ignore": {
       "version": "5.3.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,6 +20,7 @@
     "chartjs-adapter-date-fns": "^3.0.0",
     "chartjs-chart-financial": "^0.2.1",
     "chartjs-plugin-zoom": "^2.2.0",
+    "idb": "^7.1.1",
     "react": "^19.0.0",
     "react-ace": "^14.0.1",
     "react-chartjs-2": "^5.3.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -47,6 +47,7 @@
     "eslint-plugin-react-hooks": "^5.1.0",
     "eslint-plugin-react-refresh": "^0.4.19",
     "eslint-plugin-storybook": "^9.0.12",
+    "fake-indexeddb": "^6.0.1",
     "globals": "^15.15.0",
     "jsdom": "^26.1.0",
     "playwright": "^1.51.1",

--- a/frontend/src/features/datasources/DataSourceForm.tsx
+++ b/frontend/src/features/datasources/DataSourceForm.tsx
@@ -5,6 +5,7 @@ import Select from "../../components/Select";
 import Textarea from "../../components/Textarea";
 import { useLocalValue } from "../../hooks/useLocalValue";
 import { useZodForm } from "../../hooks/useZodForm";
+import { TIMEFRAME_OPTIONS } from "../../timeframes";
 
 export type DataFormat = "tick" | "ohlc";
 export type VolumeType = "none" | "actual" | "tickCount";
@@ -23,18 +24,6 @@ export type DataSourceFormProps = {
   onChange?: (value: DataSourceFormValue) => void;
   hideSourceFields?: boolean;
 };
-
-const TIMEFRAME_OPTIONS = [
-  { value: "tick", label: "ティック" },
-  { value: "1m", label: "1分足" },
-  { value: "5m", label: "5分足" },
-  { value: "15m", label: "15分足" },
-  { value: "30m", label: "30分足" },
-  { value: "1h", label: "1時間足" },
-  { value: "2h", label: "2時間足" },
-  { value: "4h", label: "4時間足" },
-  { value: "1d", label: "日足" },
-];
 
 const FORMAT_OPTIONS = [
   { value: "tick", label: "Tick" },

--- a/frontend/src/idb.test.ts
+++ b/frontend/src/idb.test.ts
@@ -1,0 +1,41 @@
+import "fake-indexeddb/auto";
+import { describe, it, expect, beforeEach } from "vitest";
+import { saveCandles, hasCandles } from "./idb";
+
+const baseTime = Date.parse("2024-01-01T00:00:00Z");
+
+async function seed(count: number) {
+  const candles = Array.from({ length: count }, (_, i) => ({
+    dataSourceId: "ds",
+    timeframe: "1h",
+    time: baseTime + i * 60 * 60 * 1000,
+    open: 1,
+    high: 1,
+    low: 1,
+    close: 1,
+  }));
+  await saveCandles("ds", "1h", candles);
+}
+
+describe("hasCandles", () => {
+  beforeEach(async () => {
+    await new Promise<void>((resolve) => {
+      const req = indexedDB.deleteDatabase("stratrack");
+      req.onsuccess = () => resolve();
+      req.onerror = () => resolve();
+      req.onblocked = () => resolve();
+    });
+  });
+
+  it("returns false when range is partially cached", async () => {
+    await seed(19); // up to 18:00
+    const ok = await hasCandles("ds", "1h", baseTime, baseTime + 20 * 60 * 60 * 1000);
+    expect(ok).toBe(false);
+  });
+
+  it("returns true when full range is cached", async () => {
+    await seed(20); // up to 19:00
+    const ok = await hasCandles("ds", "1h", baseTime, baseTime + 20 * 60 * 60 * 1000);
+    expect(ok).toBe(true);
+  });
+});

--- a/frontend/src/idb.ts
+++ b/frontend/src/idb.ts
@@ -1,0 +1,44 @@
+import { openDB, type DBSchema } from "idb";
+
+export interface Candle {
+  dataSourceId: string;
+  timeframe: string;
+  time: number;
+  open: number;
+  high: number;
+  low: number;
+  close: number;
+}
+
+interface StratrackDB extends DBSchema {
+  candles: {
+    key: [string, string, number];
+    value: Candle;
+  };
+}
+
+const dbPromise = openDB<StratrackDB>("stratrack", 1, {
+  upgrade(db) {
+    db.createObjectStore("candles", { keyPath: ["dataSourceId", "timeframe", "time"] });
+  },
+});
+
+export async function saveCandles(dsId: string, timeframe: string, candles: Candle[]) {
+  const db = await dbPromise;
+  const tx = db.transaction("candles", "readwrite");
+  for (const c of candles) {
+    await tx.store.put({ ...c, dataSourceId: dsId, timeframe });
+  }
+  await tx.done;
+}
+
+export async function loadCandles(
+  dsId: string,
+  timeframe: string,
+  from: number,
+  to: number
+): Promise<Candle[]> {
+  const db = await dbPromise;
+  const range = IDBKeyRange.bound([dsId, timeframe, from], [dsId, timeframe, to]);
+  return db.getAll("candles", range);
+}

--- a/frontend/src/routes/datasources/chart.tsx
+++ b/frontend/src/routes/datasources/chart.tsx
@@ -5,7 +5,7 @@ import { getDataStream } from "../../api/data";
 import CandlestickChart, { Candle } from "../../components/CandlestickChart";
 import Select from "../../components/Select";
 import { TIMEFRAME_OPTIONS } from "../../timeframes";
-import { loadCandles, saveCandles } from "../../idb";
+import { loadCandles, saveCandles, hasCandles } from "../../idb";
 
 const DataSourceChart = () => {
   const { dataSourceId } = useParams<{ dataSourceId: string }>();
@@ -23,7 +23,8 @@ const DataSourceChart = () => {
         const fromMs = Date.parse(from);
         const toMs = Date.parse(to);
         const cached = await loadCandles(dataSourceId, timeframe, fromMs, toMs);
-        if (cached.length) {
+        const complete = await hasCandles(dataSourceId, timeframe, fromMs, toMs);
+        if (complete) {
           setCandleData(
             cached.map((c) => ({
               date: new Date(c.time),

--- a/frontend/src/timeframes.ts
+++ b/frontend/src/timeframes.ts
@@ -9,3 +9,26 @@ export const TIMEFRAME_OPTIONS = [
   { value: "4h", label: "4時間足" },
   { value: "1d", label: "日足" },
 ];
+
+export function timeframeToMs(tf: string): number {
+  switch (tf) {
+    case "1m":
+      return 60_000;
+    case "5m":
+      return 5 * 60_000;
+    case "15m":
+      return 15 * 60_000;
+    case "30m":
+      return 30 * 60_000;
+    case "1h":
+      return 60 * 60_000;
+    case "2h":
+      return 2 * 60 * 60_000;
+    case "4h":
+      return 4 * 60 * 60_000;
+    case "1d":
+      return 24 * 60 * 60_000;
+    default:
+      return 0;
+  }
+}

--- a/frontend/src/timeframes.ts
+++ b/frontend/src/timeframes.ts
@@ -1,0 +1,11 @@
+export const TIMEFRAME_OPTIONS = [
+  { value: "tick", label: "ティック" },
+  { value: "1m", label: "1分足" },
+  { value: "5m", label: "5分足" },
+  { value: "15m", label: "15分足" },
+  { value: "30m", label: "30分足" },
+  { value: "1h", label: "1時間足" },
+  { value: "2h", label: "2時間足" },
+  { value: "4h", label: "4時間足" },
+  { value: "1d", label: "日足" },
+];


### PR DESCRIPTION
## Summary
- update the data stream function to return `text/event-stream`
- emit tick and OHLC data as SSE lines
- adjust the DataStreamFunctions test for SSE

## Testing
- `dotnet test api/stratrack-backend.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6871382b8c1883208116b8721730736f