### PR TITLE
Create ChartData context provider

### DIFF
--- a/frontend/src/features/datasources/ChartDataProvider.test.tsx
+++ b/frontend/src/features/datasources/ChartDataProvider.test.tsx
@@ -1,0 +1,168 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { createRoot } from "react-dom/client";
+import { act } from "react-dom/test-utils";
+import {
+  ChartDataProvider,
+  useChartData,
+  type ChartDataContextValue,
+} from "./ChartDataProvider";
+import * as apiDs from "../../api/datasources";
+import type { DataSourceDetail } from "../../api/datasources";
+import * as apiData from "../../api/data";
+import * as idb from "../../idb";
+
+vi.mock("../../api/datasources");
+vi.mock("../../api/data");
+vi.mock("../../idb");
+
+const baseTime = Date.parse("2024-01-01T00:00:00Z");
+const dsDetail: DataSourceDetail = {
+  id: "ds",
+  name: "ds",
+  symbol: "EURUSD",
+  timeframe: "1m",
+  format: "ohlc" as const,
+  volume: "tickCount" as const,
+  createdAt: "",
+  updatedAt: "",
+  startTime: new Date(baseTime).toISOString(),
+  endTime: new Date(baseTime + 86400000).toISOString(),
+};
+
+function Consumer({ onValue }: { onValue: (v: ChartDataContextValue) => void }) {
+  const value = useChartData();
+  onValue(value);
+  return null;
+}
+
+describe("ChartDataProvider", () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it("loads data on mount", async () => {
+    vi.mocked(apiDs.getDataSource).mockResolvedValue(dsDetail);
+    vi.mocked(apiData.getDataStream).mockResolvedValue(
+      "time,open,high,low,close\n2024-01-01T00:00:00Z,1,2,0,1"
+    );
+    vi.mocked(idb.loadCandles).mockResolvedValue([]);
+    vi.mocked(idb.hasCandles).mockResolvedValue(false);
+    vi.mocked(idb.saveCandles).mockResolvedValue();
+
+    let ctx: ChartDataContextValue | undefined;
+    const div = document.createElement("div");
+    await act(async () => {
+      const root = createRoot(div);
+      root.render(
+        <ChartDataProvider dataSourceId="ds">
+          <Consumer onValue={(v) => (ctx = v)} />
+        </ChartDataProvider>
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(apiDs.getDataSource).toHaveBeenCalledWith("ds");
+    expect(apiData.getDataStream).toHaveBeenCalled();
+    expect(ctx?.candleData.length).toBe(1);
+  });
+
+  it("uses cached data when available", async () => {
+    vi.mocked(apiDs.getDataSource).mockResolvedValue(dsDetail);
+    vi.mocked(idb.hasCandles).mockResolvedValue(true);
+    vi.mocked(idb.loadCandles).mockResolvedValue([
+      {
+        dataSourceId: "ds",
+        timeframe: "5m",
+        time: baseTime,
+        open: 1,
+        high: 2,
+        low: 0,
+        close: 1,
+      },
+    ]);
+
+    let ctx: ChartDataContextValue | undefined;
+    const div = document.createElement("div");
+    await act(async () => {
+      const root = createRoot(div);
+      root.render(
+        <ChartDataProvider dataSourceId="ds">
+          <Consumer onValue={(v) => (ctx = v)} />
+        </ChartDataProvider>
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(apiData.getDataStream).not.toHaveBeenCalled();
+    expect(ctx?.candleData[0].open).toBe(1);
+  });
+
+  it("sets error when data fetch fails", async () => {
+    vi.mocked(apiDs.getDataSource).mockResolvedValue(dsDetail);
+    vi.mocked(apiData.getDataStream).mockRejectedValue(new Error("fail"));
+    vi.mocked(idb.loadCandles).mockResolvedValue([]);
+    vi.mocked(idb.hasCandles).mockResolvedValue(false);
+
+    let ctx: ChartDataContextValue | undefined;
+    const div = document.createElement("div");
+    await act(async () => {
+      const root = createRoot(div);
+      root.render(
+        <ChartDataProvider dataSourceId="ds">
+          <Consumer onValue={(v) => (ctx = v)} />
+        </ChartDataProvider>
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(ctx?.error).toBe("fail");
+  });
+
+  it("clears data when timeframe changes", async () => {
+    vi.mocked(apiDs.getDataSource).mockResolvedValue(dsDetail);
+    vi.mocked(idb.hasCandles).mockResolvedValue(true);
+    vi.mocked(idb.loadCandles).mockResolvedValue([
+      {
+        dataSourceId: "ds",
+        timeframe: "5m",
+        time: baseTime,
+        open: 1,
+        high: 2,
+        low: 0,
+        close: 1,
+      },
+    ]);
+
+    let ctx: ChartDataContextValue | undefined;
+    const div = document.createElement("div");
+    await act(async () => {
+      const root = createRoot(div);
+      root.render(
+        <ChartDataProvider dataSourceId="ds">
+          <Consumer onValue={(v) => (ctx = v)} />
+        </ChartDataProvider>
+      );
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(ctx?.candleData.length).toBe(1);
+
+    await act(async () => {
+      ctx?.setTimeframe("1h");
+    });
+    await act(async () => {
+      await Promise.resolve();
+    });
+
+    expect(ctx?.candleData.length).toBe(0);
+  });
+});

--- a/frontend/src/features/datasources/ChartDataProvider.tsx
+++ b/frontend/src/features/datasources/ChartDataProvider.tsx
@@ -1,0 +1,176 @@
+import { createContext, useCallback, useContext, useEffect, useState } from "react";
+import { getDataSource } from "../../api/datasources";
+import { getDataStream } from "../../api/data";
+import { loadCandles, saveCandles, hasCandles } from "../../idb";
+import { Candle } from "../../components/CandlestickChart";
+
+export type Range = { from: number; to: number };
+export type ChartDataContextValue = {
+  candleData: Candle[];
+  range: Range | null;
+  dsRange: Range | null;
+  timeframe: string;
+  setTimeframe: (tf: string) => void;
+  isLoading: boolean;
+  error: string | null;
+  handleRangeChange: (range: Range) => Promise<void>;
+};
+
+const ChartDataContext = createContext<ChartDataContextValue | null>(null);
+
+export const useChartData = () => {
+  const ctx = useContext(ChartDataContext);
+  if (!ctx) throw new Error("useChartData must be used within ChartDataProvider");
+  return ctx;
+};
+
+export const ChartDataProvider = ({
+  dataSourceId,
+  children,
+}: {
+  dataSourceId: string;
+  children: React.ReactNode;
+}) => {
+  const [timeframe, setTimeframe] = useState("5m");
+  const [range, setRange] = useState<Range | null>(null);
+  const [candleData, setCandleData] = useState<Candle[]>([]);
+  const [loadedRange, setLoadedRange] = useState<Range | null>(null);
+  const [dsRange, setDsRange] = useState<Range | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const loadData = useCallback(
+    async (fromMs: number, toMs: number): Promise<Candle[]> => {
+      if (!dataSourceId) return [];
+      setIsLoading(true);
+      try {
+        const cached = await loadCandles(dataSourceId, timeframe, fromMs, toMs);
+        const complete = await hasCandles(dataSourceId, timeframe, fromMs, toMs);
+        if (complete) {
+          setError(null);
+          setIsLoading(false);
+          return cached.map((c) => ({
+            date: new Date(c.time),
+            open: c.open,
+            high: c.high,
+            low: c.low,
+            close: c.close,
+          }));
+        }
+
+        const csv = await getDataStream(
+          dataSourceId,
+          new Date(fromMs).toISOString(),
+          new Date(toMs).toISOString(),
+          "ohlc",
+          timeframe
+        );
+        const lines = csv
+          .split(/\r?\n/)
+          .map((l) => l.replace(/^data:\s*/, ""))
+          .filter((l) => l && !l.startsWith("time"));
+        const candles: Candle[] = lines.map((l) => {
+          const [t, o, h, low, c] = l.split(",");
+          return {
+            date: new Date(t),
+            open: parseFloat(o),
+            high: parseFloat(h),
+            low: parseFloat(low),
+            close: parseFloat(c),
+          };
+        });
+        await saveCandles(
+          dataSourceId,
+          timeframe,
+          candles.map((c) => ({
+            dataSourceId,
+            timeframe,
+            time: c.date.getTime(),
+            open: c.open,
+            high: c.high,
+            low: c.low,
+            close: c.close,
+          }))
+        );
+        setError(null);
+        return candles;
+      } catch (e) {
+        setError((e as Error).message);
+        return [];
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [dataSourceId, timeframe]
+  );
+
+  useEffect(() => {
+    if (!dataSourceId) return;
+    setIsLoading(true);
+    getDataSource(dataSourceId)
+      .then(async (ds) => {
+        if (ds.startTime && ds.endTime) {
+          const end = new Date(ds.endTime).getTime();
+          const start = ds.startTime ? new Date(ds.startTime).getTime() : end;
+          setDsRange({ from: start, to: end });
+          const defaultFrom = Math.max(start, end - 24 * 60 * 60 * 1000);
+          const initRange = { from: defaultFrom, to: end };
+          setRange(initRange);
+          const data = await loadData(defaultFrom, end);
+          setCandleData(data);
+          setLoadedRange(initRange);
+        }
+      })
+      .catch((e) => console.error(e))
+      .finally(() => setIsLoading(false));
+  }, [dataSourceId, loadData, timeframe]);
+
+  useEffect(() => {
+    setLoadedRange(null);
+    setCandleData([]);
+  }, [dataSourceId, timeframe]);
+
+  const handleRangeChange = async (newRange: Range) => {
+    setRange(newRange);
+    if (!loadedRange) {
+      const data = await loadData(newRange.from, newRange.to);
+      setCandleData(data);
+      setLoadedRange({ ...newRange });
+      return;
+    }
+
+    const width = newRange.to - newRange.from;
+    const margin = width * 0.2;
+    let from = loadedRange.from;
+    let to = loadedRange.to;
+    if (newRange.from - margin <= loadedRange.from) {
+      from = Math.max(dsRange?.from ?? newRange.from, loadedRange.from - width);
+    }
+    if (newRange.to + margin >= loadedRange.to) {
+      to = Math.min(dsRange?.to ?? newRange.to, loadedRange.to + width);
+    }
+
+    if (from !== loadedRange.from || to !== loadedRange.to) {
+      const data = await loadData(from, to);
+      setCandleData(data);
+      setLoadedRange({ from, to });
+    }
+  };
+
+  return (
+    <ChartDataContext.Provider
+      value={{
+        candleData,
+        range,
+        dsRange,
+        timeframe,
+        setTimeframe,
+        isLoading,
+        error,
+        handleRangeChange,
+      }}
+    >
+      {children}
+    </ChartDataContext.Provider>
+  );
+};

--- a/frontend/src/routes/datasources/chart.tsx
+++ b/frontend/src/routes/datasources/chart.tsx
@@ -1,135 +1,12 @@
-import { useEffect, useState, useCallback } from "react";
 import { useParams } from "react-router-dom";
-import { getDataSource } from "../../api/datasources";
-import { getDataStream } from "../../api/data";
-import CandlestickChart, { Candle } from "../../components/CandlestickChart";
+import CandlestickChart from "../../components/CandlestickChart";
 import Select from "../../components/Select";
 import { TIMEFRAME_OPTIONS } from "../../timeframes";
-import { loadCandles, saveCandles, hasCandles } from "../../idb";
+import { ChartDataProvider, useChartData } from "../../features/datasources/ChartDataProvider";
 
-const DataSourceChart = () => {
-  const { dataSourceId } = useParams<{ dataSourceId: string }>();
-  const [timeframe, setTimeframe] = useState("5m");
-  const [range, setRange] = useState<{ from: number; to: number } | null>(null);
-  const [candleData, setCandleData] = useState<Candle[]>([]);
-  const [loadedRange, setLoadedRange] = useState<{ from: number; to: number } | null>(null);
-  const [dsRange, setDsRange] = useState<{ from: number; to: number } | null>(null);
-  const [error, setError] = useState<string | null>(null);
-  const [isLoading, setIsLoading] = useState(false);
-
-  const loadData = useCallback(
-    async (fromMs: number, toMs: number): Promise<Candle[]> => {
-      if (!dataSourceId) return [];
-      setIsLoading(true);
-      try {
-        const cached = await loadCandles(dataSourceId, timeframe, fromMs, toMs);
-        const complete = await hasCandles(dataSourceId, timeframe, fromMs, toMs);
-        if (complete) {
-          setError(null);
-          setIsLoading(false);
-          return cached.map((c) => ({
-            date: new Date(c.time),
-            open: c.open,
-            high: c.high,
-            low: c.low,
-            close: c.close,
-          }));
-        }
-
-        const from = new Date(fromMs).toISOString();
-        const to = new Date(toMs).toISOString();
-        const csv = await getDataStream(dataSourceId, from, to, "ohlc", timeframe);
-        const lines = csv
-          .split(/\r?\n/)
-          .map((l) => l.replace(/^data:\s*/, ""))
-          .filter((l) => l && !l.startsWith("time"));
-        const candles: Candle[] = lines.map((l) => {
-          const [t, o, h, low, c] = l.split(",");
-          return {
-            date: new Date(t),
-            open: parseFloat(o),
-            high: parseFloat(h),
-            low: parseFloat(low),
-            close: parseFloat(c),
-          };
-        });
-        await saveCandles(
-          dataSourceId,
-          timeframe,
-          candles.map((c) => ({
-            dataSourceId,
-            timeframe,
-            time: c.date.getTime(),
-            open: c.open,
-            high: c.high,
-            low: c.low,
-            close: c.close,
-          }))
-        );
-        setError(null);
-        return candles;
-      } catch (e) {
-        setError((e as Error).message);
-        return [];
-      } finally {
-        setIsLoading(false);
-      }
-    },
-    [dataSourceId, timeframe]
-  );
-
-  useEffect(() => {
-    if (!dataSourceId) return;
-    setIsLoading(true);
-    getDataSource(dataSourceId)
-      .then(async (ds) => {
-        if (ds.startTime && ds.endTime) {
-          const end = new Date(ds.endTime).getTime();
-          const start = ds.startTime ? new Date(ds.startTime).getTime() : end;
-          setDsRange({ from: start, to: end });
-          const defaultFrom = Math.max(start, end - 24 * 60 * 60 * 1000);
-          const initRange = { from: defaultFrom, to: end };
-          setRange(initRange);
-          const data = await loadData(defaultFrom, end);
-          setCandleData(data);
-          setLoadedRange(initRange);
-        }
-      })
-      .catch((e) => console.error(e))
-      .finally(() => setIsLoading(false));
-  }, [dataSourceId, loadData, timeframe]);
-
-  useEffect(() => {
-    setLoadedRange(null);
-    setCandleData([]);
-  }, [dataSourceId, timeframe]);
-  const handleRangeChange = async (newRange: { from: number; to: number }) => {
-    setRange(newRange);
-    if (!loadedRange) {
-      const data = await loadData(newRange.from, newRange.to);
-      setCandleData(data);
-      setLoadedRange({ ...newRange });
-      return;
-    }
-
-    const width = newRange.to - newRange.from;
-    const margin = width * 0.2;
-    let from = loadedRange.from;
-    let to = loadedRange.to;
-    if (newRange.from - margin <= loadedRange.from) {
-      from = Math.max(dsRange?.from ?? newRange.from, loadedRange.from - width);
-    }
-    if (newRange.to + margin >= loadedRange.to) {
-      to = Math.min(dsRange?.to ?? newRange.to, loadedRange.to + width);
-    }
-
-    if (from !== loadedRange.from || to !== loadedRange.to) {
-      const data = await loadData(from, to);
-      setCandleData(data);
-      setLoadedRange({ from, to });
-    }
-  };
-
+const ChartContent = () => {
+  const { candleData, range, timeframe, setTimeframe, isLoading, error, handleRangeChange } =
+    useChartData();
   return (
     <div className="p-6 space-y-4">
       <h2 className="text-2xl font-bold">チャート表示</h2>
@@ -147,6 +24,16 @@ const DataSourceChart = () => {
         onRangeChange={handleRangeChange}
       />
     </div>
+  );
+};
+
+const DataSourceChart = () => {
+  const { dataSourceId } = useParams<{ dataSourceId: string }>();
+  if (!dataSourceId) return null;
+  return (
+    <ChartDataProvider dataSourceId={dataSourceId}>
+      <ChartContent />
+    </ChartDataProvider>
   );
 };
 


### PR DESCRIPTION
## Summary
- add `ChartDataProvider` React context for fetching and caching chart data
- refactor chart route to use the provider
- write tests for the provider to ensure loading, caching, error handling and timeframe changes work

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68719d0c7f5883208ba5b4f1ec389828