### PR TITLE
Fix chart height stretching issue

### DIFF
--- a/frontend/src/components/CandlestickChart.tsx
+++ b/frontend/src/components/CandlestickChart.tsx
@@ -96,14 +96,9 @@ const CandlestickChart = ({
   } as const;
 
   return (
-    <Chart
-      className="w-full"
-      type="candlestick"
-      data={chartData}
-      options={options}
-      width={width}
-      height={resolvedHeight}
-    />
+    <div style={{ width: width ? `${width}px` : "100%", height: resolvedHeight }}>
+      <Chart className="w-full h-full" type="candlestick" data={chartData} options={options} />
+    </div>
   );
 };
 

--- a/frontend/src/components/LineChart.tsx
+++ b/frontend/src/components/LineChart.tsx
@@ -68,7 +68,9 @@ const LineChart = ({ width, height = 300, data, range, onRangeChange }: LineChar
   } as const;
 
   return (
-    <Line className="w-full" data={chartData} options={options} width={width} height={height} />
+    <div style={{ width: width ? `${width}px` : "100%", height }}>
+      <Line className="w-full h-full" data={chartData} options={options} />
+    </div>
   );
 };
 


### PR DESCRIPTION
## Summary
- keep container height stable for CandlestickChart and LineChart

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6871acb95ccc8320bd6df29ebc8b0dd4