### PR TITLE
Stop Dukascopy job when fetch fails

### DIFF
--- a/api/Stratrack.Api/Domain/Dukascopy/DukascopyFetchService.cs
+++ b/api/Stratrack.Api/Domain/Dukascopy/DukascopyFetchService.cs
@@ -60,6 +60,7 @@ public class DukascopyFetchService(
         {
             _logger.LogError(ex, "Failed to fetch dukascopy chunk");
             error = ex.Message;
+            throw;
         }
         finally
         {


### PR DESCRIPTION
## Summary
- stop Dukascopy job when any hourly fetch fails
- run API unit tests

## Testing
- `dotnet test api/stratrack-backend.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6871b5b38c008320aff41797453717ea