### PR TITLE
Add maintenance endpoint to reset DB

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -44,3 +44,13 @@ Azurite と Azure Functions Core Tools を利用することで、Durable Functi
 2. `Stratrack.Api` ディレクトリで `func start` を実行し Functions ホストを起動します。
 3. `http://localhost:7071/api/swagger/ui` から `CreateDukascopyJob` などのエンドポイントを呼び出してください。
 4. オーケストレーターの状態は `func durable get-instances` で確認できます。
+
+## 開発用データベースリセット
+
+開発中にデータベースを初期状態へ戻したい場合、次のエンドポイントを呼び出します。
+
+```
+POST /api/maintenance/reset
+```
+
+InMemory DB と SQL Server のどちらを使用している場合でも、全てのテーブルが削除され再作成されます。

--- a/api/Stratrack.Api.Tests/MaintenanceFunctionsTests.cs
+++ b/api/Stratrack.Api.Tests/MaintenanceFunctionsTests.cs
@@ -1,0 +1,69 @@
+using EventFlow.EntityFramework;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
+using Stratrack.Api.Domain;
+using Stratrack.Api.Functions;
+using Stratrack.Api.Infrastructure;
+using Stratrack.Api.Models;
+using Stratrack.Api.Domain.DataSources;
+using System.Net;
+using System.Text.Json;
+using WorkerHttpFake;
+
+namespace Stratrack.Api.Tests;
+
+[TestClass]
+public class MaintenanceFunctionsTests
+{
+    private static ServiceProvider CreateProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddStratrack<StratrackDbContextProvider>();
+        services.AddSingleton<DataSourceFunctions>();
+        services.AddSingleton<MaintenanceFunctions>();
+        var provider = services.BuildServiceProvider();
+        using var ctx = provider.GetRequiredService<IDbContextProvider<StratrackDbContext>>().CreateContext();
+        ctx.Database.EnsureDeleted();
+        return provider;
+    }
+
+    [TestMethod]
+    public async Task ResetDatabase_RemovesAllData()
+    {
+        using var provider = CreateProvider();
+        var dsFunc = provider.GetRequiredService<DataSourceFunctions>();
+        var maintenanceFunc = provider.GetRequiredService<MaintenanceFunctions>();
+
+        var createReq = new HttpRequestDataBuilder()
+            .WithUrl("http://localhost/api/data-sources")
+            .WithMethod(HttpMethod.Post)
+            .WithBody(JsonSerializer.Serialize(new DataSourceCreateRequest
+            {
+                Name = "ds",
+                Symbol = "EURUSD",
+                Timeframe = "tick",
+                Format = DataFormat.Tick
+            }))
+            .Build();
+        var createRes = await dsFunc.PostDataSource(createReq, CancellationToken.None);
+        Assert.AreEqual(HttpStatusCode.Created, createRes.StatusCode);
+
+        using (var ctx = provider.GetRequiredService<IDbContextProvider<StratrackDbContext>>().CreateContext())
+        {
+            Assert.AreEqual(1, await ctx.DataSources.CountAsync());
+        }
+
+        var resetReq = new HttpRequestDataBuilder()
+            .WithUrl("http://localhost/api/maintenance/reset")
+            .WithMethod(HttpMethod.Post)
+            .Build();
+        var resetRes = await maintenanceFunc.ResetDatabase(resetReq, CancellationToken.None);
+        Assert.AreEqual(HttpStatusCode.NoContent, resetRes.StatusCode);
+
+        using (var ctx = provider.GetRequiredService<IDbContextProvider<StratrackDbContext>>().CreateContext())
+        {
+            Assert.AreEqual(0, await ctx.DataSources.CountAsync());
+        }
+    }
+}

--- a/api/Stratrack.Api/Functions/MaintenanceFunctions.cs
+++ b/api/Stratrack.Api/Functions/MaintenanceFunctions.cs
@@ -1,0 +1,35 @@
+using EventFlow.EntityFramework;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.OpenApi.Models;
+using System.Net;
+
+namespace Stratrack.Api.Functions;
+
+public class MaintenanceFunctions(IDbContextProvider<Stratrack.Api.Domain.StratrackDbContext> dbContextProvider)
+{
+    [Function("ResetDatabase")]
+    [OpenApiOperation(operationId: "reset_database", tags: ["Maintenance"])]
+    [OpenApiSecurity("function_key", SecuritySchemeType.ApiKey, In = OpenApiSecurityLocationType.Header, Name = "x-functions-key")]
+    [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.NoContent, Description = "No content")]
+    public async Task<HttpResponseData> ResetDatabase([
+        HttpTrigger(AuthorizationLevel.Function, "post", Route = "maintenance/reset")]
+        HttpRequestData req,
+        CancellationToken token)
+    {
+        using var context = dbContextProvider.CreateContext();
+        await context.Database.EnsureDeletedAsync(token).ConfigureAwait(false);
+        if (context.Database.IsSqlServer())
+        {
+            await context.Database.MigrateAsync(token).ConfigureAwait(false);
+        }
+        else
+        {
+            await context.Database.EnsureCreatedAsync(token).ConfigureAwait(false);
+        }
+        return req.CreateResponse(HttpStatusCode.NoContent);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `ResetDatabase` function for wiping DB
- document the new development endpoint
- add tests for the maintenance function

## Testing
- `dotnet test api/stratrack-backend.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6871baae54a88320bfa05e478fdfee30