### PR TITLE
Add maintenance endpoint to reset DB

### DIFF
--- a/api/README.md
+++ b/api/README.md
@@ -44,3 +44,13 @@ Azurite と Azure Functions Core Tools を利用することで、Durable Functi
 2. `Stratrack.Api` ディレクトリで `func start` を実行し Functions ホストを起動します。
 3. `http://localhost:7071/api/swagger/ui` から `CreateDukascopyJob` などのエンドポイントを呼び出してください。
 4. オーケストレーターの状態は `func durable get-instances` で確認できます。
+
+## 開発用データベースリセット
+
+開発中にデータベースを初期状態へ戻したい場合、次のエンドポイントを呼び出します。
+
+```
+POST /api/maintenance/reset
+```
+
+InMemory DB と SQL Server のどちらを使用している場合でも、全てのテーブルが削除され再作成されます。

--- a/api/Stratrack.Api.Tests/MaintenanceFunctionsTests.cs
+++ b/api/Stratrack.Api.Tests/MaintenanceFunctionsTests.cs
@@ -1,0 +1,70 @@
+using EventFlow.EntityFramework;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.EntityFrameworkCore;
+using Stratrack.Api.Domain;
+using Stratrack.Api.Functions;
+using Stratrack.Api.Infrastructure;
+using Stratrack.Api.Models;
+using Stratrack.Api.Domain.DataSources;
+using System.Net;
+using System.Text.Json;
+using WorkerHttpFake;
+
+namespace Stratrack.Api.Tests;
+
+[TestClass]
+public class MaintenanceFunctionsTests
+{
+    private static ServiceProvider CreateProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddStratrack<StratrackDbContextProvider>();
+        services.AddSingleton<StratrackDbContextProvider>();
+        services.AddSingleton<DataSourceFunctions>();
+        services.AddSingleton<MaintenanceFunctions>();
+        var provider = services.BuildServiceProvider();
+        using var ctx = provider.GetRequiredService<IDbContextProvider<StratrackDbContext>>().CreateContext();
+        ctx.Database.EnsureDeleted();
+        return provider;
+    }
+
+    [TestMethod]
+    public async Task ResetDatabase_RemovesAllData()
+    {
+        using var provider = CreateProvider();
+        var dsFunc = provider.GetRequiredService<DataSourceFunctions>();
+        var maintenanceFunc = provider.GetRequiredService<MaintenanceFunctions>();
+
+        var createReq = new HttpRequestDataBuilder()
+            .WithUrl("http://localhost/api/data-sources")
+            .WithMethod(HttpMethod.Post)
+            .WithBody(JsonSerializer.Serialize(new DataSourceCreateRequest
+            {
+                Name = "ds",
+                Symbol = "EURUSD",
+                Timeframe = "tick",
+                Format = DataFormat.Tick
+            }))
+            .Build();
+        var createRes = await dsFunc.PostDataSource(createReq, CancellationToken.None);
+        Assert.AreEqual(HttpStatusCode.Created, createRes.StatusCode);
+
+        using (var ctx = provider.GetRequiredService<IDbContextProvider<StratrackDbContext>>().CreateContext())
+        {
+            Assert.AreEqual(1, await ctx.DataSources.CountAsync());
+        }
+
+        var resetReq = new HttpRequestDataBuilder()
+            .WithUrl("http://localhost/api/maintenance/reset")
+            .WithMethod(HttpMethod.Post)
+            .Build();
+        var resetRes = await maintenanceFunc.ResetDatabase(resetReq, CancellationToken.None);
+        Assert.AreEqual(HttpStatusCode.NoContent, resetRes.StatusCode);
+
+        using (var ctx = provider.GetRequiredService<IDbContextProvider<StratrackDbContext>>().CreateContext())
+        {
+            Assert.AreEqual(0, await ctx.DataSources.CountAsync());
+        }
+    }
+}

--- a/api/Stratrack.Api/Functions/MaintenanceFunctions.cs
+++ b/api/Stratrack.Api/Functions/MaintenanceFunctions.cs
@@ -1,0 +1,36 @@
+using EventFlow.EntityFramework;
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.OpenApi.Models;
+using System.Net;
+using Stratrack.Api.Infrastructure;
+
+namespace Stratrack.Api.Functions;
+
+public class MaintenanceFunctions(StratrackDbContextProvider dbContextProvider)
+{
+    [Function("ResetDatabase")]
+    [OpenApiOperation(operationId: "reset_database", tags: ["Maintenance"])]
+    [OpenApiSecurity("function_key", SecuritySchemeType.ApiKey, In = OpenApiSecurityLocationType.Header, Name = "x-functions-key")]
+    [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.NoContent, Description = "No content")]
+    public async Task<HttpResponseData> ResetDatabase([
+        HttpTrigger(AuthorizationLevel.Function, "post", Route = "maintenance/reset")]
+        HttpRequestData req,
+        CancellationToken token)
+    {
+        using var context = dbContextProvider.CreateContextWithoutInitialization();
+        await context.Database.EnsureDeletedAsync(token).ConfigureAwait(false);
+        if (context.Database.IsSqlServer())
+        {
+            await context.Database.MigrateAsync(token).ConfigureAwait(false);
+        }
+        else
+        {
+            await context.Database.EnsureCreatedAsync(token).ConfigureAwait(false);
+        }
+        return req.CreateResponse(HttpStatusCode.NoContent);
+    }
+}

--- a/api/Stratrack.Api/Infrastructure/StratrackDbContextProvider.cs
+++ b/api/Stratrack.Api/Infrastructure/StratrackDbContextProvider.cs
@@ -43,6 +43,15 @@ public class StratrackDbContextProvider : IDbContextProvider<StratrackDbContext>
         return context;
     }
 
+    /// <summary>
+    /// Create context without applying migrations. Used only for development
+    /// scenarios such as resetting the database when migrations fail.
+    /// </summary>
+    public StratrackDbContext CreateContextWithoutInitialization()
+    {
+        return new StratrackDbContext(_options);
+    }
+
     public void Dispose()
     {
     }

--- a/api/Stratrack.Api/Program.cs
+++ b/api/Stratrack.Api/Program.cs
@@ -20,6 +20,7 @@ builder.Services
         options.PropertyNameCaseInsensitive = true;
         options.Converters.Add(new JsonStringEnumConverter(JsonNamingPolicy.CamelCase));
     })
-    .AddStratrack<StratrackDbContextProvider>();
+    .AddStratrack<StratrackDbContextProvider>()
+    .AddSingleton<StratrackDbContextProvider>();
 
 builder.Build().Run();

--- a/frontend/src/api/maintenance.ts
+++ b/frontend/src/api/maintenance.ts
@@ -1,0 +1,12 @@
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "";
+const API_KEY = import.meta.env.VITE_API_KEY ?? "";
+
+export async function resetDatabase() {
+  const res = await fetch(`${API_BASE_URL}/api/maintenance/reset`, {
+    method: "POST",
+    headers: { "x-functions-key": API_KEY },
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to reset database: ${res.status}`);
+  }
+}

--- a/frontend/src/routes/settings/index.stories.tsx
+++ b/frontend/src/routes/settings/index.stories.tsx
@@ -20,5 +20,6 @@ export const Default: Story = {
     const canvas = within(canvasElement);
     await expect(canvas.getByText("設定")).toBeInTheDocument();
     await expect(canvas.getByText("Dukascopyジョブ管理")).toBeInTheDocument();
+    await expect(canvas.getByText("データベースリセット")).toBeInTheDocument();
   },
 };

--- a/frontend/src/routes/settings/index.tsx
+++ b/frontend/src/routes/settings/index.tsx
@@ -1,4 +1,6 @@
 import { Link } from "react-router-dom";
+import Button from "../../components/Button";
+import { resetDatabase } from "../../api/maintenance";
 
 const Settings = () => {
   return (
@@ -29,6 +31,22 @@ const Settings = () => {
             >
               開く
             </Link>
+          </div>
+          <div className="rounded-xl border p-4 shadow">
+            <h4 className="font-bold">データベースリセット</h4>
+            <p className="text-sm text-gray-600">開発用データベースを初期化します</p>
+            <Button
+              className="mt-2"
+              onClick={async () => {
+                if (!confirm("本当にリセットしますか？")) {
+                  return;
+                }
+                await resetDatabase();
+                alert("リセットしました");
+              }}
+            >
+              実行
+            </Button>
           </div>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- implement `ResetDatabase` function for wiping DB
- document the new development endpoint
- add tests for the maintenance function
- add context factory without migrations for development

## Testing
- `dotnet test api/stratrack-backend.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6871baae54a88320bfa05e478fdfee30