### PR TITLE
Fix chart range callbacks

### DIFF
--- a/frontend/src/components/CandlestickChart.tsx
+++ b/frontend/src/components/CandlestickChart.tsx
@@ -79,17 +79,20 @@ const CandlestickChart = ({
           wheel: { enabled: true },
           pinch: { enabled: true },
           mode: "x",
+          onZoomComplete: ({ chart }: { chart: ChartJS }) => {
+            const from = chart.scales.x.min as number;
+            const to = chart.scales.x.max as number;
+            onRangeChange?.({ from, to });
+          },
         },
-        pan: { enabled: true, mode: "x" },
-        onZoomComplete: ({ chart }: { chart: ChartJS }) => {
-          const from = chart.scales.x.min as number;
-          const to = chart.scales.x.max as number;
-          onRangeChange?.({ from, to });
-        },
-        onPanComplete: ({ chart }: { chart: ChartJS }) => {
-          const from = chart.scales.x.min as number;
-          const to = chart.scales.x.max as number;
-          onRangeChange?.({ from, to });
+        pan: {
+          enabled: true,
+          mode: "x",
+          onPanComplete: ({ chart }: { chart: ChartJS }) => {
+            const from = chart.scales.x.min as number;
+            const to = chart.scales.x.max as number;
+            onRangeChange?.({ from, to });
+          },
         },
       },
     },


### PR DESCRIPTION
## Summary
- handle zoom/pan events inside the proper chartjs-plugin-zoom options

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687228ebb1b88320aff255bd8aa11253