### PR TITLE
Fix chart range callbacks

### DIFF
--- a/frontend/src/components/CandlestickChart.stories.tsx
+++ b/frontend/src/components/CandlestickChart.stories.tsx
@@ -18,5 +18,6 @@ export const Default: Story = {
       { date: new Date(2), open: 1.0, high: 1.2, low: 0.9, close: 1.15 },
       { date: new Date(3), open: 1.15, high: 1.25, low: 1.05, close: 1.1 },
     ],
+    limits: { from: 0, to: 3 },
   },
 };

--- a/frontend/src/components/CandlestickChart.tsx
+++ b/frontend/src/components/CandlestickChart.tsx
@@ -26,6 +26,7 @@ export type CandlestickChartProps = {
   width?: number;
   height?: number;
   range?: { from: number; to: number };
+  limits?: { from: number; to: number };
   onRangeChange?: (range: { from: number; to: number }) => void;
 };
 
@@ -47,6 +48,7 @@ const CandlestickChart = ({
   width,
   height = 300,
   range,
+  limits,
   onRangeChange,
 }: CandlestickChartProps) => {
   const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
@@ -79,18 +81,29 @@ const CandlestickChart = ({
           wheel: { enabled: true },
           pinch: { enabled: true },
           mode: "x",
+          onZoomComplete: ({ chart }: { chart: ChartJS }) => {
+            const from = chart.scales.x.min as number;
+            const to = chart.scales.x.max as number;
+            onRangeChange?.({ from, to });
+          },
         },
-        pan: { enabled: true, mode: "x" },
-        onZoomComplete: ({ chart }: { chart: ChartJS }) => {
-          const from = chart.scales.x.min as number;
-          const to = chart.scales.x.max as number;
-          onRangeChange?.({ from, to });
+        pan: {
+          enabled: true,
+          mode: "x",
+          onPanComplete: ({ chart }: { chart: ChartJS }) => {
+            const from = chart.scales.x.min as number;
+            const to = chart.scales.x.max as number;
+            onRangeChange?.({ from, to });
+          },
         },
-        onPanComplete: ({ chart }: { chart: ChartJS }) => {
-          const from = chart.scales.x.min as number;
-          const to = chart.scales.x.max as number;
-          onRangeChange?.({ from, to });
-        },
+        limits: limits
+          ? {
+              x: {
+                min: limits.from,
+                max: limits.to,
+              },
+            }
+          : undefined,
       },
     },
   } as const;

--- a/frontend/src/routes/datasources/chart.tsx
+++ b/frontend/src/routes/datasources/chart.tsx
@@ -5,8 +5,16 @@ import { TIMEFRAME_OPTIONS } from "../../timeframes";
 import { ChartDataProvider, useChartData } from "../../features/datasources/ChartDataProvider";
 
 const ChartContent = () => {
-  const { candleData, range, timeframe, setTimeframe, isLoading, error, handleRangeChange } =
-    useChartData();
+  const {
+    candleData,
+    range,
+    dsRange,
+    timeframe,
+    setTimeframe,
+    isLoading,
+    error,
+    handleRangeChange,
+  } = useChartData();
   return (
     <div className="p-6 space-y-4">
       <h2 className="text-2xl font-bold">チャート表示</h2>
@@ -21,6 +29,7 @@ const ChartContent = () => {
       <CandlestickChart
         data={candleData}
         range={range ?? undefined}
+        limits={dsRange ?? undefined}
         onRangeChange={handleRangeChange}
       />
     </div>


### PR DESCRIPTION
## Summary
- handle zoom/pan events inside the proper chartjs-plugin-zoom options
- clamp panning and zooming to the available dataset range

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_687228ebb1b88320aff255bd8aa11253