### PR TITLE
Add pair scaling and chunk deletion

### DIFF
--- a/api/Stratrack.Api.Tests/DukascopyClientTests.cs
+++ b/api/Stratrack.Api.Tests/DukascopyClientTests.cs
@@ -16,4 +16,17 @@ public class DukascopyClientTests
         var result = await client.GetTickDataAsync("EURUSD", new DateTimeOffset(2000,1,1,0,0,0,TimeSpan.Zero), CancellationToken.None);
         Assert.AreEqual(404, result.HttpStatus);
     }
+
+    [TestMethod]
+    public void GetScaleDigits_Returns3ForJpyPairs()
+    {
+        Assert.AreEqual(3, DukascopyClient.GetScaleDigits("USDJPY"));
+        Assert.AreEqual(3, DukascopyClient.GetScaleDigits("EURJPY"));
+    }
+
+    [TestMethod]
+    public void GetScaleDigits_Returns5ForOthers()
+    {
+        Assert.AreEqual(5, DukascopyClient.GetScaleDigits("EURUSD"));
+    }
 }

--- a/api/Stratrack.Api.Tests/DukascopyJobFunctionsTests.cs
+++ b/api/Stratrack.Api.Tests/DukascopyJobFunctionsTests.cs
@@ -91,7 +91,7 @@ public class DukascopyJobFunctionsTests
             .WithUrl($"http://localhost/api/dukascopy-job/{id}/execute")
             .WithMethod(HttpMethod.Post)
             .Build();
-        var execRes = await execFunc.StartExecution(execReq, id, client.Object, CancellationToken.None);
+        var execRes = await execFunc.StartDukascopyJobExecution(execReq, id, client.Object, CancellationToken.None);
         Assert.AreEqual(HttpStatusCode.Accepted, execRes.StatusCode);
 
         var deleteReq = new HttpRequestDataBuilder()

--- a/api/Stratrack.Api/AssemblyInfo.cs
+++ b/api/Stratrack.Api/AssemblyInfo.cs
@@ -1,0 +1,2 @@
+using System.Runtime.CompilerServices;
+[assembly: InternalsVisibleTo("Stratrack.Api.Tests")]

--- a/frontend/src/api/data.ts
+++ b/frontend/src/api/data.ts
@@ -61,3 +61,18 @@ export async function getDataStream(
   }
   return res.text();
 }
+
+export async function deleteDataChunks(dataSourceId: string, startTime?: string, endTime?: string) {
+  const params = new URLSearchParams();
+  if (startTime) params.append("startTime", startTime);
+  if (endTime) params.append("endTime", endTime);
+  const query = params.toString();
+  const url = `${API_BASE_URL}/api/data-sources/${dataSourceId}/chunks${query ? `?${query}` : ""}`;
+  const res = await fetch(url, {
+    method: "DELETE",
+    headers: { "x-functions-key": API_KEY },
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to delete data chunks: ${res.status}`);
+  }
+}

--- a/frontend/src/routes/settings/DukascopyJobCard.stories.tsx
+++ b/frontend/src/routes/settings/DukascopyJobCard.stories.tsx
@@ -17,6 +17,7 @@ const meta = {
     onToggle: fn(),
     onRun: fn(),
     onInterrupt: fn(),
+    onDeleteData: fn(),
   },
 } satisfies Meta<typeof DukascopyJobCard>;
 

--- a/frontend/src/routes/settings/DukascopyJobCard.tsx
+++ b/frontend/src/routes/settings/DukascopyJobCard.tsx
@@ -23,6 +23,7 @@ type Props = {
   onToggle: (pair: string) => void;
   onRun: (pair: string) => void;
   onInterrupt: (pair: string) => void;
+  onDeleteData: (pair: string) => void;
 };
 
 const DukascopyJobCard = ({
@@ -33,6 +34,7 @@ const DukascopyJobCard = ({
   onToggle,
   onRun,
   onInterrupt,
+  onDeleteData,
 }: Props) => {
   const isLoading = !job.loaded;
   return (
@@ -63,6 +65,16 @@ const DukascopyJobCard = ({
             isLoading={disabled}
           >
             中断
+          </Button>
+        )}
+        {job.dataSourceId && (
+          <Button
+            size="sm"
+            onClick={() => onDeleteData(pair)}
+            disabled={disabled}
+            isLoading={disabled}
+          >
+            データ削除
           </Button>
         )}
       </div>

--- a/frontend/src/routes/settings/dukascopy-jobs.tsx
+++ b/frontend/src/routes/settings/dukascopy-jobs.tsx
@@ -11,8 +11,20 @@ import {
   listDukascopyJobs,
   DukascopyJobSummary,
 } from "../../api/dukascopyJobs";
+import { deleteDataChunks } from "../../api/data";
 
-const PAIRS = ["EURUSD", "USDJPY", "GBPUSD", "AUDUSD", "EURJPY"];
+const PAIRS = [
+  "EURUSD",
+  "USDJPY",
+  "GBPUSD",
+  "AUDUSD",
+  "EURJPY",
+  "GBPJPY",
+  "AUDJPY",
+  "USDCHF",
+  "USDCAD",
+  "NZDUSD",
+];
 
 const initialState: Record<string, JobState> = Object.fromEntries(
   PAIRS.map((p) => [
@@ -148,6 +160,20 @@ const DukascopyJobs = () => {
     }
   };
 
+  const handleDeleteData = async (pair: string) => {
+    const job = jobs[pair];
+    if (!job.dataSourceId) return;
+    setIsSubmitting(true);
+    setError(null);
+    try {
+      await deleteDataChunks(job.dataSourceId);
+    } catch (err) {
+      setError((err as Error).message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
   return (
     <div className="p-6 space-y-6">
       <header>
@@ -170,6 +196,7 @@ const DukascopyJobs = () => {
             onToggle={handleToggle}
             onRun={handleRun}
             onInterrupt={handleInterrupt}
+            onDeleteData={handleDeleteData}
           />
         ))}
       </div>


### PR DESCRIPTION
## Summary
- handle JPY pairs correctly in `DukascopyClient`
- expose helper for scale digits and test it
- allow deleting data chunks from the frontend
- extend Dukascopy job UI to support more pairs and data removal

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run build`
- `dotnet test api/stratrack-backend.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_68798bf08f0c832094a13ad5f840ae79