### PR TITLE
Implement additional literal support in mql-interpreter

### DIFF
--- a/libs/mql-interpreter/src/expression.ts
+++ b/libs/mql-interpreter/src/expression.ts
@@ -50,6 +50,10 @@ export function evaluateExpression(
       consume();
       return { value: t.value };
     }
+    if (t.type === TokenType.Keyword && (t.value === 'true' || t.value === 'false')) {
+      consume();
+      return { value: t.value === 'true' ? 1 : 0 };
+    }
     if (t.type === TokenType.Identifier) {
       consume();
       const name = t.value;
@@ -70,6 +74,9 @@ export function evaluateExpression(
         }
         consume(TokenType.Punctuation, ')');
         return { value: callFunction(runtime, name, args) };
+      }
+      if (runtime && runtime.enumMembers[name] !== undefined) {
+        return { value: runtime.enumMembers[name] };
       }
       return { value: env[name], ref: name };
     }

--- a/libs/mql-interpreter/src/lexer.ts
+++ b/libs/mql-interpreter/src/lexer.ts
@@ -188,14 +188,108 @@ export function lex(source: string): LexResult {
       tokens.push({ type: TokenType.String, value, line: startLine, column: startCol });
       continue;
     }
+    // character constant
+    if (char === "'") {
+      const startLine = line;
+      const startCol = column;
+      advance();
+      let val: number | null = null;
+      if (source[i] === '\\') {
+        advance();
+        const esc = source[i];
+        advance();
+        switch (esc) {
+          case 'n': val = 10; break;
+          case 't': val = 9; break;
+          case 'r': val = 13; break;
+          case '\\': val = 92; break;
+          case "'": val = 39; break;
+          case '"': val = 34; break;
+          case 'x': {
+            let hex = '';
+            while (i < source.length && /[0-9a-fA-F]/.test(source[i])) {
+              hex += source[i];
+              advance();
+            }
+            val = parseInt(hex || '0', 16);
+            break;
+          }
+          default: {
+            let digits = esc;
+            while (i < source.length && /[0-9]/.test(source[i])) {
+              digits += source[i];
+              advance();
+            }
+            if (/^[0-9]+$/.test(digits)) val = parseInt(digits, 10);
+            else val = digits.charCodeAt(0);
+          }
+        }
+      } else {
+        val = source.charCodeAt(i);
+        advance();
+      }
+      if (source[i] === "'") advance();
+      else errors.push({ message: 'Unterminated char constant', line: startLine, column: startCol });
+      tokens.push({ type: TokenType.Number, value: String(val ?? 0), line: startLine, column: startCol });
+      continue;
+    }
+    // color literal C'..'
+    if ((char === 'C' || char === 'c') && source[i + 1] === "'") {
+      const startLine = line;
+      const startCol = column;
+      advance(2); // skip C'
+      let inner = '';
+      while (i < source.length && source[i] !== "'") { inner += source[i]; advance(); }
+      if (source[i] === "'") advance();
+      const parts = inner.split(',').map(s => s.trim());
+      const parseComp = (s: string) => s.startsWith('0x') || s.startsWith('0X') ? parseInt(s,16) : parseInt(s,10);
+      const r = parseComp(parts[0] || '0');
+      const g = parseComp(parts[1] || '0');
+      const b = parseComp(parts[2] || '0');
+      const val = r + (g << 8) + (b << 16);
+      tokens.push({ type: TokenType.Number, value: String(val), line: startLine, column: startCol });
+      continue;
+    }
+    // datetime literal D'..'
+    if ((char === 'D' || char === 'd') && source[i + 1] === "'") {
+      const startLine = line;
+      const startCol = column;
+      advance(2);
+      let inner = '';
+      while (i < source.length && source[i] !== "'") { inner += source[i]; advance(); }
+      if (source[i] === "'") advance();
+      let val = 0;
+      const re1 = /^(\d{4})\.(\d{1,2})\.(\d{1,2})(?:\s+(\d{1,2})(?::(\d{1,2})(?::(\d{1,2}))?)?)?$/;
+      const re2 = /^(\d{1,2})\.(\d{1,2})\.(\d{4})(?:\s+(\d{1,2})(?::(\d{1,2})(?::(\d{1,2}))?)?)?$/;
+      let m = inner.match(re1);
+      if (!m) m = inner.match(re2);
+      if (m) {
+        const year = parseInt(m[1]);
+        const month = parseInt(m[2]);
+        const day = parseInt(m[3]);
+        const hour = parseInt(m[4] || '0');
+        const min = parseInt(m[5] || '0');
+        const sec = parseInt(m[6] || '0');
+        val = Math.floor(Date.UTC(year, month - 1, day, hour, min, sec) / 1000);
+      }
+      tokens.push({ type: TokenType.Number, value: String(val), line: startLine, column: startCol });
+      continue;
+    }
     // number literal
-    if (/\d/.test(char)) {
+    if (/\d/.test(char) || (char === '.' && /\d/.test(source[i + 1]))) {
       let value = '';
       const startLine = line;
       const startCol = column;
-      while (i < source.length && /[0-9.]/.test(source[i])) {
+      if (char === '0' && (source[i + 1] === 'x' || source[i + 1] === 'X')) {
+        value += '0';
+        advance();
         value += source[i];
         advance();
+        while (i < source.length && /[0-9a-fA-F]/.test(source[i])) { value += source[i]; advance(); }
+      } else {
+        while (i < source.length && /[0-9]/.test(source[i])) { value += source[i]; advance(); }
+        if (i < source.length && source[i] === '.') { value += '.'; advance(); while (i < source.length && /[0-9]/.test(source[i])) { value += source[i]; advance(); } }
+        if (i < source.length && /[eE]/.test(source[i])) { value += source[i]; advance(); if (source[i] === '+' || source[i] === '-') { value += source[i]; advance(); } while (i < source.length && /[0-9]/.test(source[i])) { value += source[i]; advance(); } }
       }
       tokens.push({ type: TokenType.Number, value, line: startLine, column: startCol });
       continue;

--- a/libs/mql-interpreter/src/runtime.ts
+++ b/libs/mql-interpreter/src/runtime.ts
@@ -26,6 +26,8 @@ export interface RuntimeClassMethod {
 
 export interface Runtime {
   enums: Record<string, Record<string, number>>;
+  /** Lookup table of enumeration member names to numeric values */
+  enumMembers: Record<string, number>;
   classes: Record<string, { base?: string; abstract?: boolean; templateParams?: string[]; fields: Record<string, RuntimeClassField>; methods: RuntimeClassMethod[] }>;
   functions: Record<string, { returnType: string; parameters: RuntimeFunctionParameter[]; locals: VariableDeclaration[]; body?: string; templateParams?: string[] }[]>;
   variables: Record<string, { type: string; storage?: 'static' | 'input' | 'extern'; dimensions: Array<number | null>; initialValue?: string }>;
@@ -70,6 +72,7 @@ export function execute(
 ): Runtime {
   const runtime: Runtime = {
     enums: {},
+    enumMembers: {},
     classes: {},
     functions: {},
     variables: {},
@@ -119,6 +122,7 @@ export function execute(
           current = parseInt(member.value, 10);
         }
         members[member.name] = current;
+        runtime.enumMembers[member.name] = current;
         current++;
       }
       runtime.enums[decl.name] = members;

--- a/libs/mql-interpreter/test/literals.test.ts
+++ b/libs/mql-interpreter/test/literals.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { evaluateExpression } from '../src/expression';
+import { compile } from '../src';
+
+describe('literal expressions', () => {
+  it('parses boolean constants', () => {
+    expect(evaluateExpression('true')).toBe(1);
+    expect(evaluateExpression('false')).toBe(0);
+  });
+
+  it('parses hexadecimal and scientific numbers', () => {
+    expect(evaluateExpression('0x10')).toBe(16);
+    expect(evaluateExpression('1e2')).toBe(100);
+    expect(evaluateExpression('0.5')).toBe(0.5);
+  });
+
+  it('parses character constants', () => {
+    expect(evaluateExpression("'A'")).toBe(65);
+    expect(evaluateExpression("'\\n'")).toBe(10);
+    expect(evaluateExpression("'\\x41'")).toBe(65);
+  });
+
+  it('parses color literals', () => {
+    expect(evaluateExpression("C'255,0,0'")).toBe(0x0000ff);
+    expect(evaluateExpression("C'0,0,255'")).toBe(0xff0000);
+  });
+
+  it('parses datetime literals', () => {
+    expect(evaluateExpression("D'1970.01.01 00:00:01'")).toBe(1);
+  });
+
+  it('parses enumeration constants', () => {
+    const { runtime } = compile('enum E{ A=2,B };');
+    expect(evaluateExpression('A', {}, runtime)).toBe(2);
+    expect(evaluateExpression('B', {}, runtime)).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- add runtime lookup table for enumeration members
- handle boolean and enumeration constants in `evaluateExpression`
- extend lexer to parse char, color, datetime, hex and scientific literals
- add tests covering the new literal formats

## Testing
- `npm test --silent`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6885bcc95314832092f0e89fa678c531