### PR TITLE
Add scrollable charts with storybook tests

### DIFF
--- a/frontend/src/components/CandlestickChart.stories.tsx
+++ b/frontend/src/components/CandlestickChart.stories.tsx
@@ -45,3 +45,22 @@ export const Default: Story = {
     await expect(args.onRangeChange).toHaveBeenCalled();
   },
 };
+
+export const Tooltip: Story = {
+  args: {
+    width: 300,
+    height: 200,
+    data: Array.from({ length: 120 }, (_, i) => ({
+      date: new Date(i * 60 * 1000),
+      open: 1 + Math.sin(i / 10) * 0.05,
+      high: 1.1 + Math.sin(i / 10) * 0.05,
+      low: 0.9 + Math.sin(i / 10) * 0.05,
+      close: 1 + Math.sin((i + 1) / 10) * 0.05,
+    })),
+  },
+  play: async ({ canvasElement }) => {
+    const firstBar = canvasElement.querySelector("rect") as SVGRectElement;
+    fireEvent.click(firstBar);
+    await expect(canvasElement.querySelector("foreignObject")).not.toBeNull();
+  },
+};

--- a/frontend/src/components/CandlestickChart.stories.tsx
+++ b/frontend/src/components/CandlestickChart.stories.tsx
@@ -64,3 +64,41 @@ export const Tooltip: Story = {
     await expect(canvasElement.querySelector("foreignObject")).not.toBeNull();
   },
 };
+
+export const WithSubchart: Story = {
+  args: {
+    width: 300,
+    height: 150,
+    data: Array.from({ length: 50 }, (_, i) => ({
+      date: new Date(i * 60 * 1000),
+      open: 1 + Math.sin(i / 5) * 0.05,
+      high: 1.1 + Math.sin(i / 5) * 0.05,
+      low: 0.9 + Math.sin(i / 5) * 0.05,
+      close: 1 + Math.sin((i + 1) / 5) * 0.05,
+    })),
+    indicators: [
+      {
+        name: "MA",
+        color: "#3b82f6",
+        data: Array.from({ length: 50 }, (_, i) => ({
+          date: new Date(i * 60 * 1000),
+          value: 1 + Math.sin(i / 5) * 0.04,
+        })),
+      },
+      {
+        name: "RSI",
+        color: "#10b981",
+        pane: 1,
+        data: Array.from({ length: 50 }, (_, i) => ({
+          date: new Date(i * 60 * 1000),
+          value: 50 + Math.sin(i / 5) * 10,
+        })),
+      },
+    ],
+  },
+  play: async ({ canvasElement, args }) => {
+    const svgs = canvasElement.querySelectorAll("svg");
+    fireEvent.wheel(svgs[1], { deltaY: 100 });
+    await expect(args.onRangeChange).toHaveBeenCalled();
+  },
+};

--- a/frontend/src/components/CandlestickChart.stories.tsx
+++ b/frontend/src/components/CandlestickChart.stories.tsx
@@ -1,8 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn, fireEvent, expect } from "storybook/test";
 import CandlestickChart from "./CandlestickChart";
 
 const meta: Meta<typeof CandlestickChart> = {
   component: CandlestickChart,
+  args: {
+    onRangeChange: fn(),
+  },
 };
 export default meta;
 
@@ -34,5 +38,10 @@ export const Default: Story = {
       { date: new Date(1), price: 1.1, type: "buy" },
       { date: new Date(2), price: 1.15, type: "sell" },
     ],
+  },
+  play: async ({ canvasElement, args }) => {
+    const svg = canvasElement.querySelector("svg") as SVGSVGElement;
+    fireEvent.wheel(svg, { deltaY: 100 });
+    await expect(args.onRangeChange).toHaveBeenCalled();
   },
 };

--- a/frontend/src/components/CandlestickChart.tsx
+++ b/frontend/src/components/CandlestickChart.tsx
@@ -16,6 +16,11 @@ export type Indicator = {
   name: string;
   color?: string;
   data: { date: Date; value: number }[];
+  /**
+   * 0 or undefined means overlay on main chart. Higher numbers show in
+   * separate subcharts stacked below the main candlestick chart.
+   */
+  pane?: number;
 };
 
 export type BacktestTrade = {
@@ -35,6 +40,94 @@ export type CandlestickChartProps = {
 };
 
 const AXIS_HEIGHT = 20;
+
+type SubChartProps = {
+  pane: number;
+  indicators: Indicator[];
+  range: { from: number; to: number };
+  formatTick: (d: Date) => string;
+  handlePointerDown: (e: React.PointerEvent<SVGSVGElement>) => void;
+  handlePointerMoveGeneric: (e: React.PointerEvent<SVGSVGElement>, width: number) => void;
+  handleWheel: (e: React.WheelEvent<SVGSVGElement>) => void;
+  endDrag: () => void;
+};
+
+const SubChart = ({
+  pane,
+  indicators,
+  range,
+  formatTick,
+  handlePointerDown,
+  handlePointerMoveGeneric,
+  handleWheel,
+  endDrag,
+}: SubChartProps) => {
+  const [size, setSize] = React.useState({ width: 0, height: 0 });
+  const onResize = (w: number, h: number) => setSize({ width: w, height: h });
+  const chartHeight = Math.max(0, size.height - AXIS_HEIGHT);
+  const xScale = scaleTime().domain([range.from, range.to]).range([0, size.width]);
+  const values = indicators.flatMap((i) =>
+    i.data
+      .filter((p) => p.date.getTime() >= range.from && p.date.getTime() <= range.to)
+      .map((p) => p.value)
+  );
+  const min = Math.min(...values);
+  const max = Math.max(...values);
+  const yScale = scaleLinear().domain([min, max]).range([chartHeight, 0]).nice();
+  const yTicks = yScale.ticks(5);
+  const ticks = xScale.ticks(Math.max(2, Math.floor(size.width / 80)));
+  const paths = indicators.map((ind) => ({
+    color: ind.color || "#0ea5e9",
+    path:
+      d3Line<{ date: Date; value: number }>()
+        .x((d) => xScale(d.date.getTime()))
+        .y((d) => yScale(d.value))(
+        ind.data.filter((p) => p.date.getTime() >= range.from && p.date.getTime() <= range.to)
+      ) ?? "",
+  }));
+  return (
+    <div key={`pane-${pane}`} style={{ height: 100 + AXIS_HEIGHT }}>
+      <ResponsiveContainer width="100%" height="100%" onResize={onResize}>
+        <svg
+          width={size.width}
+          height={size.height}
+          style={{ overflow: "visible" }}
+          onWheel={handleWheel}
+          onPointerDown={handlePointerDown}
+          onPointerMove={(e) => handlePointerMoveGeneric(e, size.width)}
+          onPointerUp={endDrag}
+          onPointerLeave={endDrag}
+        >
+          {paths.map((p, idx) => (
+            <path key={idx} d={p.path} fill="none" stroke={p.color} />
+          ))}
+          {yTicks.map((p, idx) => {
+            const y = yScale(p);
+            return (
+              <g key={`ytick-${idx}`}>
+                <line x1={0} x2={size.width} y1={y} y2={y} stroke="#e5e7eb" strokeDasharray="2 2" />
+                <text x={-4} y={y + 3} textAnchor="end" fontSize={10} fill="#64748b">
+                  {p.toFixed(2)}
+                </text>
+              </g>
+            );
+          })}
+          {ticks.map((t, idx) => {
+            const x = xScale(t.getTime());
+            return (
+              <g key={`tick-${idx}`}>
+                <line x1={x} x2={x} y1={chartHeight} y2={chartHeight + 4} stroke="#94a3b8" />
+                <text x={x} y={chartHeight + 14} textAnchor="middle" fontSize={10} fill="#64748b">
+                  {formatTick(t)}
+                </text>
+              </g>
+            );
+          })}
+        </svg>
+      </ResponsiveContainer>
+    </div>
+  );
+};
 
 const CandlestickChart = ({
   data,
@@ -87,15 +180,19 @@ const CandlestickChart = ({
     setTooltip(null);
   };
 
-  const handlePointerMove = (e: React.PointerEvent<SVGSVGElement>) => {
+  const handlePointerMoveGeneric = (e: React.PointerEvent<SVGSVGElement>, width: number) => {
     if (dragStart.current == null || !dragRange.current || !onRangeChange) return;
     const dx = e.clientX - dragStart.current;
-    const ratio = -dx / size.width;
+    const ratio = -dx / width;
     const widthMs = dragRange.current.to - dragRange.current.from;
     onRangeChange({
       from: dragRange.current.from + widthMs * ratio,
       to: dragRange.current.to + widthMs * ratio,
     });
+  };
+
+  const handlePointerMove = (e: React.PointerEvent<SVGSVGElement>) => {
+    handlePointerMoveGeneric(e, size.width);
   };
 
   const handleBarClick = (c: Candle, x: number, y: number) => {
@@ -127,108 +224,141 @@ const CandlestickChart = ({
   );
   const yTicks = yScale.ticks(5);
 
-  const indLines = indicators?.map((ind) => ({
+  const overlayIndicators = indicators?.filter((ind) => ind.pane === undefined || ind.pane === 0);
+  const indLines = overlayIndicators?.map((ind) => ({
     color: ind.color || "#0ea5e9",
     path:
       d3Line<{ date: Date; value: number }>()
         .x((d) => xScale(d.date.getTime()))
         .y((d) => yScale(d.value))(ind.data) ?? "",
   }));
+  const subIndicators = indicators?.filter((ind) => (ind.pane ?? 0) > 0) ?? [];
+  const subPaneMap = React.useMemo(() => {
+    const m = new Map<number, Indicator[]>();
+    subIndicators.forEach((ind) => {
+      const p = ind.pane ?? 1;
+      if (!m.has(p)) m.set(p, []);
+      m.get(p)!.push(ind);
+    });
+    return new Map(Array.from(m.entries()).sort((a, b) => a[0] - b[0]));
+  }, [subIndicators]);
   const tradeItems = trades?.filter((t) => t.date.getTime() >= from && t.date.getTime() <= to);
 
   return (
-    <div style={{ width: width ? `${width}px` : "100%", height: resolvedHeight + AXIS_HEIGHT }}>
-      <ResponsiveContainer width="100%" height="100%" onResize={onResize}>
-        <svg
-          width={size.width}
-          height={size.height}
-          style={{ overflow: "visible" }}
-          onWheel={handleWheel}
-          onPointerDown={handlePointerDown}
-          onPointerMove={handlePointerMove}
-          onPointerUp={endDrag}
-          onPointerLeave={endDrag}
-        >
-          {filtered.map((c, i) => {
-            const x = xScale(c.date.getTime());
-            const openY = yScale(c.open);
-            const closeY = yScale(c.close);
-            const highY = yScale(c.high);
-            const lowY = yScale(c.low);
-            const color = c.close >= c.open ? "#16a34a" : "#ef4444";
-            return (
-              <g key={i} onClick={() => handleBarClick(c, x, Math.min(openY, closeY))}>
-                <line x1={x} x2={x} y1={highY} y2={lowY} stroke={color} />
-                <rect
-                  x={x - candleW / 2}
-                  y={Math.min(openY, closeY)}
-                  width={candleW}
-                  height={Math.max(1, Math.abs(openY - closeY))}
-                  fill={color}
-                />
-              </g>
-            );
-          })}
-          {indLines?.map((ind, idx) => (
-            <path key={idx} d={ind.path} fill="none" stroke={ind.color} />
-          ))}
-          {tradeItems?.map((t, idx) => {
-            const x = xScale(t.date.getTime());
-            const y = yScale(t.price);
-            const size = 6;
-            const points =
-              t.type === "buy"
-                ? `${x},${y - size} ${x - size},${y + size} ${x + size},${y + size}`
-                : `${x},${y + size} ${x - size},${y - size} ${x + size},${y - size}`;
-            return <polygon key={idx} points={points} fill="#eab308" />;
-          })}
-          {yTicks.map((p, idx) => {
-            const y = yScale(p);
-            return (
-              <g key={`ytick-${idx}`}>
-                <line x1={0} x2={size.width} y1={y} y2={y} stroke="#e5e7eb" strokeDasharray="2 2" />
-                <text x={-4} y={y + 3} textAnchor="end" fontSize={10} fill="#64748b">
-                  {p.toFixed(2)}
-                </text>
-              </g>
-            );
-          })}
-          {ticks.map((t, idx) => {
-            const x = xScale(t.getTime());
-            return (
-              <g key={`tick-${idx}`}>
-                <line x1={x} x2={x} y1={chartHeight} y2={chartHeight + 4} stroke="#94a3b8" />
-                <text x={x} y={chartHeight + 14} textAnchor="middle" fontSize={10} fill="#64748b">
-                  {formatTick(t)}
-                </text>
-              </g>
-            );
-          })}
-          {tooltip && (
-            <foreignObject
-              x={tooltip.x}
-              y={tooltip.y - 45}
-              width={100}
-              height={40}
-              style={{ pointerEvents: "none" }}
-            >
-              <div
-                style={{
-                  background: "#fff",
-                  border: "1px solid #94a3b8",
-                  fontSize: 10,
-                  padding: 2,
-                }}
+    <div style={{ width: width ? `${width}px` : "100%" }}>
+      <div style={{ height: resolvedHeight + AXIS_HEIGHT }}>
+        <ResponsiveContainer width="100%" height="100%" onResize={onResize}>
+          <svg
+            width={size.width}
+            height={size.height}
+            style={{ overflow: "visible" }}
+            onWheel={handleWheel}
+            onPointerDown={handlePointerDown}
+            onPointerMove={handlePointerMove}
+            onPointerUp={endDrag}
+            onPointerLeave={endDrag}
+          >
+            {filtered.map((c, i) => {
+              const x = xScale(c.date.getTime());
+              const openY = yScale(c.open);
+              const closeY = yScale(c.close);
+              const highY = yScale(c.high);
+              const lowY = yScale(c.low);
+              const color = c.close >= c.open ? "#16a34a" : "#ef4444";
+              return (
+                <g key={i} onClick={() => handleBarClick(c, x, Math.min(openY, closeY))}>
+                  <line x1={x} x2={x} y1={highY} y2={lowY} stroke={color} />
+                  <rect
+                    x={x - candleW / 2}
+                    y={Math.min(openY, closeY)}
+                    width={candleW}
+                    height={Math.max(1, Math.abs(openY - closeY))}
+                    fill={color}
+                  />
+                </g>
+              );
+            })}
+            {indLines?.map((ind, idx) => (
+              <path key={idx} d={ind.path} fill="none" stroke={ind.color} />
+            ))}
+            {tradeItems?.map((t, idx) => {
+              const x = xScale(t.date.getTime());
+              const y = yScale(t.price);
+              const size = 6;
+              const points =
+                t.type === "buy"
+                  ? `${x},${y - size} ${x - size},${y + size} ${x + size},${y + size}`
+                  : `${x},${y + size} ${x - size},${y - size} ${x + size},${y - size}`;
+              return <polygon key={idx} points={points} fill="#eab308" />;
+            })}
+            {yTicks.map((p, idx) => {
+              const y = yScale(p);
+              return (
+                <g key={`ytick-${idx}`}>
+                  <line
+                    x1={0}
+                    x2={size.width}
+                    y1={y}
+                    y2={y}
+                    stroke="#e5e7eb"
+                    strokeDasharray="2 2"
+                  />
+                  <text x={-4} y={y + 3} textAnchor="end" fontSize={10} fill="#64748b">
+                    {p.toFixed(2)}
+                  </text>
+                </g>
+              );
+            })}
+            {ticks.map((t, idx) => {
+              const x = xScale(t.getTime());
+              return (
+                <g key={`tick-${idx}`}>
+                  <line x1={x} x2={x} y1={chartHeight} y2={chartHeight + 4} stroke="#94a3b8" />
+                  <text x={x} y={chartHeight + 14} textAnchor="middle" fontSize={10} fill="#64748b">
+                    {formatTick(t)}
+                  </text>
+                </g>
+              );
+            })}
+            {tooltip && (
+              <foreignObject
+                x={tooltip.x}
+                y={tooltip.y - 45}
+                width={100}
+                height={40}
+                style={{ pointerEvents: "none" }}
               >
-                <div>O:{tooltip.candle.open}</div>
-                <div>H:{tooltip.candle.high}</div>
-                <div>L:{tooltip.candle.low}</div>
-                <div>C:{tooltip.candle.close}</div>
-              </div>
-            </foreignObject>
-          )}
-        </svg>
-      </ResponsiveContainer>
+                <div
+                  style={{
+                    background: "#fff",
+                    border: "1px solid #94a3b8",
+                    fontSize: 10,
+                    padding: 2,
+                  }}
+                >
+                  <div>O:{tooltip.candle.open}</div>
+                  <div>H:{tooltip.candle.high}</div>
+                  <div>L:{tooltip.candle.low}</div>
+                  <div>C:{tooltip.candle.close}</div>
+                </div>
+              </foreignObject>
+            )}
+          </svg>
+        </ResponsiveContainer>
+      </div>
+      {Array.from(subPaneMap.entries()).map(([pane, inds]) => (
+        <SubChart
+          key={pane}
+          pane={pane}
+          indicators={inds}
+          range={{ from, to }}
+          formatTick={formatTick}
+          handlePointerDown={handlePointerDown}
+          handlePointerMoveGeneric={handlePointerMoveGeneric}
+          handleWheel={handleWheel}
+          endDrag={endDrag}
+        />
+      ))}
     </div>
   );
 };

--- a/frontend/src/components/LineChart.stories.tsx
+++ b/frontend/src/components/LineChart.stories.tsx
@@ -1,8 +1,12 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { fn, fireEvent, expect } from "storybook/test";
 import LineChart from "./LineChart";
 
 const meta: Meta<typeof LineChart> = {
   component: LineChart,
+  args: {
+    onRangeChange: fn(),
+  },
 };
 export default meta;
 
@@ -18,5 +22,10 @@ export const Default: Story = {
       { x: 2, y: 1.5 },
       { x: 3, y: 3 },
     ],
+  },
+  play: async ({ canvasElement, args }) => {
+    const svg = canvasElement.querySelector("svg") as SVGSVGElement;
+    fireEvent.wheel(svg, { deltaY: 100 });
+    await expect(args.onRangeChange).toHaveBeenCalled();
   },
 };

--- a/frontend/src/components/LineChart.stories.tsx
+++ b/frontend/src/components/LineChart.stories.tsx
@@ -29,3 +29,11 @@ export const Default: Story = {
     await expect(args.onRangeChange).toHaveBeenCalled();
   },
 };
+
+export const LongData: Story = {
+  args: {
+    width: 300,
+    height: 150,
+    data: Array.from({ length: 150 }, (_, i) => ({ x: i, y: Math.sin(i / 10) })),
+  },
+};

--- a/frontend/src/components/LineChart.tsx
+++ b/frontend/src/components/LineChart.tsx
@@ -1,3 +1,4 @@
+import React from "react";
 import {
   ResponsiveContainer,
   LineChart as ReLineChart,
@@ -15,15 +16,63 @@ export type LineChartProps = {
   height?: number;
   data: LinePoint[];
   range?: { from: number; to: number };
+  onRangeChange?: (range: { from: number; to: number }) => void;
 };
 
-const LineChart = ({ width, height = 300, data, range }: LineChartProps) => {
+const LineChart = ({ width, height = 300, data, range, onRangeChange }: LineChartProps) => {
   const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
   const resolvedHeight = isMobile ? 200 : height;
-  const filtered = range ? data.filter((p) => p.x >= range.from && p.x <= range.to) : data;
+  const from = range?.from ?? data[0]?.x ?? 0;
+  const to = range?.to ?? data[data.length - 1]?.x ?? 0;
+  const filtered = data.filter((p) => p.x >= from && p.x <= to);
+  const [size, setSize] = React.useState({ width: 0, height: 0 });
+  const onResize = (w: number, h: number) => setSize({ width: w, height: h });
+  const dragStart = React.useRef<number | null>(null);
+  const dragRange = React.useRef<{ from: number; to: number } | null>(null);
+
+  const moveRange = (ratio: number) => {
+    if (!onRangeChange) return;
+    const widthMs = to - from;
+    onRangeChange({ from: from + widthMs * ratio, to: to + widthMs * ratio });
+  };
+
+  const handleWheel = (e: React.WheelEvent<HTMLDivElement>) => {
+    if (!onRangeChange) return;
+    e.preventDefault();
+    const ratio = (e.deltaY > 0 ? 1 : -1) * 0.1;
+    moveRange(ratio);
+  };
+
+  const handlePointerDown = (e: React.PointerEvent<HTMLDivElement>) => {
+    dragStart.current = e.clientX;
+    dragRange.current = { from, to };
+  };
+
+  const handlePointerMove = (e: React.PointerEvent<HTMLDivElement>) => {
+    if (dragStart.current == null || !dragRange.current || !onRangeChange) return;
+    const dx = e.clientX - dragStart.current;
+    const ratio = -dx / size.width;
+    const widthMs = dragRange.current.to - dragRange.current.from;
+    onRangeChange({
+      from: dragRange.current.from + widthMs * ratio,
+      to: dragRange.current.to + widthMs * ratio,
+    });
+  };
+
+  const endDrag = () => {
+    dragStart.current = null;
+    dragRange.current = null;
+  };
   return (
-    <div style={{ width: width ? `${width}px` : "100%", height: resolvedHeight }}>
-      <ResponsiveContainer width="100%" height="100%">
+    <div
+      style={{ width: width ? `${width}px` : "100%", height: resolvedHeight }}
+      onWheel={handleWheel}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={endDrag}
+      onPointerLeave={endDrag}
+    >
+      <ResponsiveContainer width="100%" height="100%" onResize={onResize}>
         <ReLineChart data={filtered} margin={{ top: 5, right: 20, bottom: 5, left: 0 }}>
           <CartesianGrid strokeDasharray="3 3" />
           <XAxis

--- a/frontend/src/components/LineChart.tsx
+++ b/frontend/src/components/LineChart.tsx
@@ -22,8 +22,14 @@ export type LineChartProps = {
 const LineChart = ({ width, height = 300, data, range, onRangeChange }: LineChartProps) => {
   const isMobile = typeof window !== "undefined" && window.innerWidth < 768;
   const resolvedHeight = isMobile ? 200 : height;
-  const from = range?.from ?? data[0]?.x ?? 0;
-  const to = range?.to ?? data[data.length - 1]?.x ?? 0;
+  const defaultRange = React.useMemo(() => {
+    if (data.length === 0) return { from: 0, to: 0 };
+    const endIdx = data.length - 1;
+    const startIdx = Math.max(0, endIdx - 99);
+    return { from: data[startIdx].x, to: data[endIdx].x };
+  }, [data]);
+  const from = range?.from ?? defaultRange.from;
+  const to = range?.to ?? defaultRange.to;
   const filtered = data.filter((p) => p.x >= from && p.x <= to);
   const [size, setSize] = React.useState({ width: 0, height: 0 });
   const onResize = (w: number, h: number) => setSize({ width: w, height: h });


### PR DESCRIPTION
## Summary
- enable scroll and drag range changes in CandlestickChart and LineChart
- test chart interaction with Storybook play functions

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6885bd70a26883209aa4ca6ac6306986