### PR TITLE
Add data history API

### DIFF
--- a/api/Stratrack.Api.Tests/DataHistoryFunctionsTests.cs
+++ b/api/Stratrack.Api.Tests/DataHistoryFunctionsTests.cs
@@ -50,7 +50,7 @@ public class DataHistoryFunctionsTests
     }
 
     [TestMethod]
-    public async Task GetDataHistory_ReturnsCsv()
+    public async Task GetDataHistory_ReturnsJson()
     {
         using var provider = CreateProvider();
         var dsId = await CreateDataSourceAsync(provider);
@@ -70,12 +70,14 @@ public class DataHistoryFunctionsTests
 
         var histFunc = provider.GetRequiredService<DataHistoryFunctions>();
         var req = new HttpRequestDataBuilder()
-            .WithUrl($"http://localhost/api/data-sources/{dsId}/history?timeframe=1m&endTime=2024-01-01T01:00:00Z")
+            .WithUrl($"http://localhost/api/data-sources/{dsId}/history?timeframe=1m&startTime=2024-01-01T00:00:00Z&endTime=2024-01-01T01:00:00Z")
             .WithMethod(HttpMethod.Get)
             .Build();
         var res = await histFunc.GetDataHistory(req, dsId, CancellationToken.None);
         Assert.AreEqual(HttpStatusCode.OK, res.StatusCode);
         var body = await res.ReadAsStringAsync();
-        Assert.IsTrue(body.StartsWith("time,open,high,low,close"));
+        var points = JsonSerializer.Deserialize<List<HistoryOhlc>>(body);
+        Assert.IsNotNull(points);
+        Assert.AreEqual(0, points.Count);
     }
 }

--- a/api/Stratrack.Api.Tests/DataHistoryFunctionsTests.cs
+++ b/api/Stratrack.Api.Tests/DataHistoryFunctionsTests.cs
@@ -1,0 +1,81 @@
+using EventFlow.EntityFramework;
+using Microsoft.Extensions.DependencyInjection;
+using Stratrack.Api.Domain;
+using Stratrack.Api.Functions;
+using Stratrack.Api.Infrastructure;
+using Stratrack.Api.Models;
+using Stratrack.Api.Domain.DataSources;
+using System.Net;
+using System.Text;
+using System.Text.Json;
+using WorkerHttpFake;
+
+namespace Stratrack.Api.Tests;
+
+[TestClass]
+public class DataHistoryFunctionsTests
+{
+    private static ServiceProvider CreateProvider()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddStratrack<StratrackDbContextProvider>();
+        services.AddSingleton<DataSourceFunctions>();
+        services.AddSingleton<DataChunkFunctions>();
+        services.AddSingleton<DataHistoryFunctions>();
+        var provider = services.BuildServiceProvider();
+        using var ctx = provider.GetRequiredService<IDbContextProvider<StratrackDbContext>>().CreateContext();
+        ctx.Database.EnsureDeleted();
+        return provider;
+    }
+
+    private static async Task<string> CreateDataSourceAsync(ServiceProvider provider)
+    {
+        var func = provider.GetRequiredService<DataSourceFunctions>();
+        var req = new HttpRequestDataBuilder()
+            .WithUrl("http://localhost/api/data-sources")
+            .WithMethod(HttpMethod.Post)
+            .WithBody(JsonSerializer.Serialize(new DataSourceCreateRequest
+            {
+                Name = "ds",
+                Symbol = "EURUSD",
+                Timeframe = "tick",
+                Format = DataFormat.Tick,
+                Volume = VolumeType.None
+            }))
+            .Build();
+        var res = await func.PostDataSource(req, CancellationToken.None);
+        var detail = await res.ReadAsJsonAsync<DataSourceDetail>();
+        return detail.Id.ToString();
+    }
+
+    [TestMethod]
+    public async Task GetDataHistory_ReturnsCsv()
+    {
+        using var provider = CreateProvider();
+        var dsId = await CreateDataSourceAsync(provider);
+        var chunkFunc = provider.GetRequiredService<DataChunkFunctions>();
+        var data = Convert.ToBase64String(Encoding.UTF8.GetBytes("time,bid,ask\n"));
+        var uploadReq = new HttpRequestDataBuilder()
+            .WithUrl($"http://localhost/api/data-sources/{dsId}/chunks")
+            .WithMethod(HttpMethod.Post)
+            .WithBody(JsonSerializer.Serialize(new CsvChunkUploadRequest
+            {
+                StartTime = new DateTimeOffset(2024,1,1,0,0,0,TimeSpan.Zero),
+                EndTime = new DateTimeOffset(2024,1,1,1,0,0,TimeSpan.Zero),
+                Base64Data = data
+            }))
+            .Build();
+        await chunkFunc.PostDataChunk(uploadReq, dsId, CancellationToken.None);
+
+        var histFunc = provider.GetRequiredService<DataHistoryFunctions>();
+        var req = new HttpRequestDataBuilder()
+            .WithUrl($"http://localhost/api/data-sources/{dsId}/history?timeframe=1m&endTime=2024-01-01T01:00:00Z")
+            .WithMethod(HttpMethod.Get)
+            .Build();
+        var res = await histFunc.GetDataHistory(req, dsId, CancellationToken.None);
+        Assert.AreEqual(HttpStatusCode.OK, res.StatusCode);
+        var body = await res.ReadAsStringAsync();
+        Assert.IsTrue(body.StartsWith("time,open,high,low,close"));
+    }
+}

--- a/api/Stratrack.Api.Tests/DataHistoryFunctionsTests.cs
+++ b/api/Stratrack.Api.Tests/DataHistoryFunctionsTests.cs
@@ -8,6 +8,7 @@ using Stratrack.Api.Domain.DataSources;
 using System.Net;
 using System.Text;
 using System.Text.Json;
+using System.Linq;
 using WorkerHttpFake;
 
 namespace Stratrack.Api.Tests;
@@ -70,11 +71,15 @@ public class DataHistoryFunctionsTests
 
         var histFunc = provider.GetRequiredService<DataHistoryFunctions>();
         var req = new HttpRequestDataBuilder()
-            .WithUrl($"http://localhost/api/data-sources/{dsId}/history?timeframe=1m&startTime=2024-01-01T00:00:00Z&endTime=2024-01-01T01:00:00Z")
+            .WithUrl($"http://localhost/api/data-sources/{dsId}/history?timeframe=1m&time=2024-01-01T01:00:00Z")
             .WithMethod(HttpMethod.Get)
             .Build();
         var res = await histFunc.GetDataHistory(req, dsId, CancellationToken.None);
         Assert.AreEqual(HttpStatusCode.OK, res.StatusCode);
+        Assert.IsTrue(res.Headers.TryGetValues("X-Start-Time", out var sVals));
+        Assert.IsTrue(res.Headers.TryGetValues("X-End-Time", out var eVals));
+        Assert.AreEqual("2023-12-31T01:00:00.0000000Z", sVals.First());
+        Assert.AreEqual("2024-01-01T01:00:00.0000000Z", eVals.First());
         var body = await res.ReadAsStringAsync();
         var points = JsonSerializer.Deserialize<List<HistoryOhlc>>(body);
         Assert.IsNotNull(points);

--- a/api/Stratrack.Api/Functions/DataHistoryFunctions.cs
+++ b/api/Stratrack.Api/Functions/DataHistoryFunctions.cs
@@ -1,0 +1,201 @@
+using Microsoft.Azure.Functions.Worker;
+using Microsoft.Azure.Functions.Worker.Http;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Attributes;
+using Microsoft.Azure.WebJobs.Extensions.OpenApi.Core.Enums;
+using Microsoft.OpenApi.Models;
+using Microsoft.Extensions.Logging;
+using Stratrack.Api.Domain.Blobs;
+using Stratrack.Api.Domain.DataSources;
+using Stratrack.Api.Domain.DataSources.Queries;
+using EventFlow.Queries;
+using System.Net;
+using System.Text;
+using System.Linq;
+
+namespace Stratrack.Api.Functions;
+
+public class DataHistoryFunctions(
+    IQueryProcessor queryProcessor,
+    IBlobStorage blobStorage,
+    ILogger<DataHistoryFunctions> logger)
+{
+    private readonly IQueryProcessor _queryProcessor = queryProcessor;
+    private readonly IBlobStorage _blobStorage = blobStorage;
+    private readonly ILogger<DataHistoryFunctions> _logger = logger;
+
+    [Function("GetDataHistory")]
+    [OpenApiOperation(operationId: "get_data_history", tags: ["DataSources"])]
+    [OpenApiSecurity("function_key", SecuritySchemeType.ApiKey, In = OpenApiSecurityLocationType.Header, Name = "x-functions-key")]
+    [OpenApiParameter(name: "dataSourceId", In = ParameterLocation.Path, Required = true, Type = typeof(string))]
+    [OpenApiParameter(name: "timeframe", In = ParameterLocation.Query, Required = false, Type = typeof(string))]
+    [OpenApiParameter(name: "endTime", In = ParameterLocation.Query, Required = false, Type = typeof(string))]
+    [OpenApiResponseWithBody(statusCode: HttpStatusCode.OK, contentType: "text/csv", bodyType: typeof(string))]
+    [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.NotFound, Description = "Not found")]
+    [OpenApiResponseWithoutBody(statusCode: HttpStatusCode.UnprocessableEntity, Description = "Unprocessable entity")]
+    public async Task<HttpResponseData> GetDataHistory(
+        [HttpTrigger(AuthorizationLevel.Function, "get", Route = "data-sources/{dataSourceId}/history")] HttpRequestData req,
+        string dataSourceId,
+        CancellationToken token)
+    {
+        var query = System.Web.HttpUtility.ParseQueryString(req.Url.Query);
+        var timeframe = query.Get("timeframe");
+        var endStr = query.Get("endTime");
+
+        var dsId = Guid.Parse(dataSourceId);
+        var sources = await _queryProcessor.ProcessAsync(new DataSourceReadModelSearchQuery(), token).ConfigureAwait(false);
+        var dataSource = sources.FirstOrDefault(d => d.DataSourceId == dsId);
+        if (dataSource == null)
+        {
+            return req.CreateResponse(HttpStatusCode.NotFound);
+        }
+
+        timeframe ??= dataSource.Timeframe;
+        DateTimeOffset end = endStr != null ? DateTimeOffset.Parse(endStr) : DateTimeOffset.UtcNow;
+        var start = end - GetDefaultRange(timeframe);
+
+        var chunks = await _queryProcessor.ProcessAsync(new DataChunkReadModelSearchQuery(dsId), token).ConfigureAwait(false);
+        var target = chunks
+            .Where(c => c.StartTime < end && c.EndTime > start)
+            .OrderBy(c => c.StartTime)
+            .ToList();
+
+        if (target.Count == 0)
+        {
+            var prev = chunks
+                .Where(c => c.EndTime <= start)
+                .OrderByDescending(c => c.EndTime)
+                .FirstOrDefault();
+            if (prev != null)
+            {
+                target.Add(prev);
+            }
+        }
+
+        var lines = new List<string>();
+        foreach (var chunk in target)
+        {
+            var data = await _blobStorage.GetAsync(chunk.BlobId, token).ConfigureAwait(false);
+            var text = Encoding.UTF8.GetString(data);
+            lines.AddRange(text.Split('\n', StringSplitOptions.RemoveEmptyEntries).Skip(1));
+        }
+
+        var filtered = lines.Where(l =>
+        {
+            var parts = l.Split(',');
+            if (parts.Length < 2) return false;
+            var time = DateTimeOffset.Parse(parts[0]);
+            return time >= start && time < end;
+        });
+
+        var sb = new StringBuilder();
+        if (timeframe == "tick")
+        {
+            sb.AppendLine("time,bid,ask");
+            foreach (var line in filtered.OrderBy(l => DateTimeOffset.Parse(l.Split(',')[0])))
+            {
+                sb.AppendLine(line);
+            }
+        }
+        else
+        {
+            sb.AppendLine("time,open,high,low,close");
+            int tfMinutes = ParseTimeframeMinutes(timeframe);
+            var ohlc = BuildOhlc(filtered, dataSource.Format, tfMinutes, start, end);
+            foreach (var c in ohlc)
+            {
+                sb.AppendLine($"{c.Time:o},{c.Open},{c.High},{c.Low},{c.Close}");
+            }
+        }
+
+        var response = req.CreateResponse(HttpStatusCode.OK);
+        response.Headers.Add("Content-Type", "text/csv");
+        await response.WriteStringAsync(sb.ToString(), token).ConfigureAwait(false);
+        return response;
+    }
+
+    private static TimeSpan GetDefaultRange(string timeframe)
+    {
+        return timeframe switch
+        {
+            "tick" => TimeSpan.FromHours(1),
+            "1m" => TimeSpan.FromDays(1),
+            "5m" => TimeSpan.FromDays(7),
+            "15m" => TimeSpan.FromDays(14),
+            "30m" => TimeSpan.FromDays(30),
+            "1h" => TimeSpan.FromDays(60),
+            "4h" => TimeSpan.FromDays(180),
+            "1d" => TimeSpan.FromDays(365),
+            _ => TimeSpan.FromDays(1),
+        };
+    }
+
+    private static int ParseTimeframeMinutes(string timeframe)
+    {
+        return timeframe switch
+        {
+            "1m" => 1,
+            "5m" => 5,
+            "15m" => 15,
+            "30m" => 30,
+            "1h" => 60,
+            "2h" => 120,
+            "4h" => 240,
+            "1d" => 1440,
+            _ => 0,
+        };
+    }
+
+    private static IEnumerable<(DateTimeOffset Time, decimal Open, decimal High, decimal Low, decimal Close)> BuildOhlc(IEnumerable<string> lines, DataFormat format, int tfMinutes, DateTimeOffset start, DateTimeOffset end)
+    {
+        var entries = new List<(DateTimeOffset Time, decimal Open, decimal High, decimal Low, decimal Close)>();
+        foreach (var line in lines)
+        {
+            var parts = line.Split(',');
+            if (parts.Length < 2) continue;
+            var time = DateTimeOffset.Parse(parts[0]);
+            if (time < start || time >= end) continue;
+            if (format == DataFormat.Tick)
+            {
+                var price = decimal.Parse(parts[1]);
+                entries.Add((time, price, price, price, price));
+            }
+            else
+            {
+                if (parts.Length < 5) continue;
+                var open = decimal.Parse(parts[1]);
+                var high = decimal.Parse(parts[2]);
+                var low = decimal.Parse(parts[3]);
+                var close = decimal.Parse(parts[4]);
+                entries.Add((time, open, high, low, close));
+            }
+        }
+
+        if (tfMinutes <= 0)
+        {
+            foreach (var e in entries.OrderBy(e => e.Time))
+            {
+                yield return e;
+            }
+            yield break;
+        }
+
+        var group = entries
+            .OrderBy(e => e.Time)
+            .GroupBy(e => AlignTime(e.Time, tfMinutes));
+
+        foreach (var g in group)
+        {
+            var first = g.First();
+            var last = g.Last();
+            yield return (g.Key, first.Open, g.Max(x => x.High), g.Min(x => x.Low), last.Close);
+        }
+    }
+
+    private static DateTimeOffset AlignTime(DateTimeOffset time, int minutes)
+    {
+        if (minutes <= 0) return time;
+        var ticks = time.UtcTicks - (time.UtcTicks % TimeSpan.FromMinutes(minutes).Ticks);
+        return new DateTimeOffset(ticks, TimeSpan.Zero);
+    }
+}
+

--- a/api/Stratrack.Api/Models/HistoryOhlc.cs
+++ b/api/Stratrack.Api/Models/HistoryOhlc.cs
@@ -1,0 +1,10 @@
+namespace Stratrack.Api.Models;
+
+public class HistoryOhlc
+{
+    public DateTimeOffset Time { get; set; }
+    public decimal Open { get; set; }
+    public decimal High { get; set; }
+    public decimal Low { get; set; }
+    public decimal Close { get; set; }
+}

--- a/api/Stratrack.Api/Models/HistoryTick.cs
+++ b/api/Stratrack.Api/Models/HistoryTick.cs
@@ -1,0 +1,8 @@
+namespace Stratrack.Api.Models;
+
+public class HistoryTick
+{
+    public DateTimeOffset Time { get; set; }
+    public decimal Bid { get; set; }
+    public decimal Ask { get; set; }
+}

--- a/frontend/src/features/datasources/ChartDataProvider.test.tsx
+++ b/frontend/src/features/datasources/ChartDataProvider.test.tsx
@@ -39,9 +39,11 @@ describe("ChartDataProvider", () => {
 
   it("loads data on mount", async () => {
     vi.mocked(apiDs.getDataSource).mockResolvedValue(dsDetail);
-    vi.mocked(apiData.getDataStream).mockResolvedValue(
-      "time,open,high,low,close\n2024-01-01T00:00:00Z,1,2,0,1"
-    );
+    vi.mocked(apiData.getDataHistory).mockResolvedValue({
+      data: [{ time: "2024-01-01T00:00:00Z", open: 1, high: 2, low: 0, close: 1 }],
+      startTime: "2023-12-31T00:00:00Z",
+      endTime: "2024-01-01T00:00:00Z",
+    });
     vi.mocked(idb.loadCandles).mockResolvedValue([]);
     vi.mocked(idb.hasCandles).mockResolvedValue(false);
     vi.mocked(idb.saveCandles).mockResolvedValue();
@@ -61,7 +63,7 @@ describe("ChartDataProvider", () => {
     });
 
     expect(apiDs.getDataSource).toHaveBeenCalledWith("ds");
-    expect(apiData.getDataStream).toHaveBeenCalled();
+    expect(apiData.getDataHistory).toHaveBeenCalled();
     expect(ctx?.candleData.length).toBe(1);
   });
 
@@ -94,13 +96,13 @@ describe("ChartDataProvider", () => {
       await Promise.resolve();
     });
 
-    expect(apiData.getDataStream).not.toHaveBeenCalled();
+    expect(apiData.getDataHistory).not.toHaveBeenCalled();
     expect(ctx?.candleData[0].open).toBe(1);
   });
 
   it("sets error when data fetch fails", async () => {
     vi.mocked(apiDs.getDataSource).mockResolvedValue(dsDetail);
-    vi.mocked(apiData.getDataStream).mockRejectedValue(new Error("fail"));
+    vi.mocked(apiData.getDataHistory).mockRejectedValue(new Error("fail"));
     vi.mocked(idb.loadCandles).mockResolvedValue([]);
     vi.mocked(idb.hasCandles).mockResolvedValue(false);
 
@@ -168,9 +170,11 @@ describe("ChartDataProvider", () => {
       endTime: new Date(baseTime + 2 * 86400000).toISOString(),
     };
     vi.mocked(apiDs.getDataSource).mockResolvedValue(extendedDs);
-    vi.mocked(apiData.getDataStream).mockResolvedValue(
-      "time,open,high,low,close\n2024-01-02T00:00:00Z,1,2,0,1"
-    );
+    vi.mocked(apiData.getDataHistory).mockResolvedValue({
+      data: [{ time: "2024-01-02T00:00:00Z", open: 1, high: 2, low: 0, close: 1 }],
+      startTime: "2024-01-01T00:00:00Z",
+      endTime: "2024-01-02T00:00:00Z",
+    });
     vi.mocked(idb.loadCandles).mockResolvedValue([]);
     vi.mocked(idb.hasCandles).mockResolvedValue(false);
     vi.mocked(idb.saveCandles).mockResolvedValue();
@@ -189,7 +193,7 @@ describe("ChartDataProvider", () => {
       await Promise.resolve();
     });
 
-    expect(apiData.getDataStream).toHaveBeenCalledTimes(1);
+    expect(apiData.getDataHistory).toHaveBeenCalledTimes(1);
     const initialRange = ctx!.range!;
 
     await act(async () => {
@@ -202,6 +206,6 @@ describe("ChartDataProvider", () => {
       await Promise.resolve();
     });
 
-    expect(apiData.getDataStream).toHaveBeenCalledTimes(2);
+    expect(apiData.getDataHistory).toHaveBeenCalledTimes(2);
   });
 });


### PR DESCRIPTION
## Summary
- add Azure function `GetDataHistory` for retrieving historical chart data in CSV
- create new test verifying CSV output

## Testing
- `dotnet test api/stratrack-backend.sln -c Release`

------
https://chatgpt.com/codex/tasks/task_e_6885cfa4a7888320b4ceddc5b985669f