### PR TITLE
Improve CLI backtest reports

### DIFF
--- a/libs/mql-interpreter/README.md
+++ b/libs/mql-interpreter/README.md
@@ -189,6 +189,16 @@ npx mql-interpreter bad.mq4
 1:1 Unknown type Foo
 ```
 
+To run a quick backtest, supply the `--backtest` option with candle data in CSV
+format. Optionally set `--data-dir` to mimic the MT4 data folder so global
+variables persist between runs. Results now include account metrics and the
+executed order list in addition to globals. Output is JSON by default or an
+HTML snippet when `--format html` is provided:
+
+```bash
+npx mql-interpreter test.mq4 --backtest candles.csv --data-dir ./tmp --format html > report.html
+```
+
 ## Architecture
 
 1. **Preprocessing** – source code is passed through the preprocessor which

--- a/libs/mql-interpreter/src/index.ts
+++ b/libs/mql-interpreter/src/index.ts
@@ -120,7 +120,7 @@ import {
   PropertyMap,
   PreprocessOptions,
 } from './preprocess';
-import { BacktestRunner, parseCsv } from './backtest';
+import { BacktestRunner, parseCsv, BacktestReport } from './backtest';
 import { MarketData, Tick, Candle, ticksToCandles } from './market';
 import { Broker, OrderState } from './broker';
 import { Account } from './account';
@@ -202,6 +202,7 @@ export {
   LexResult,
   Candle,
   BacktestRunner,
+  BacktestReport,
   Broker,
   Account,
   MarketData,
@@ -439,6 +440,7 @@ export function interpret(
         runtime.globalValues[name] = context.externValues[name];
       }
     }
+    runtime.context = context;
     if (context.entryPoint) {
       callFunction(runtime, context.entryPoint, context.args);
     }

--- a/libs/mql-interpreter/src/runtime.ts
+++ b/libs/mql-interpreter/src/runtime.ts
@@ -34,6 +34,8 @@ export interface Runtime {
   staticLocals: Record<string, Record<string, any>>;
   /** Values of global variables */
   globalValues: Record<string, any>;
+  /** Execution context used when running entry points */
+  context?: ExecutionContext;
 }
 
 import { Declaration, ClassDeclaration, FunctionDeclaration, VariableDeclaration } from './parser';
@@ -129,7 +131,7 @@ export function execute(
   const entryArgs = ctx.args ?? [];
   const inputVals = ctx.inputValues ?? {};
   const externVals = ctx.externValues ?? {};
-  // TODO: support a full execution context when function bodies are interpreted.
+  runtime.context = ctx;
   const enumMembers: Record<string, number> = {};
 
   for (const decl of declarations) {

--- a/libs/mql-interpreter/test/backtest.test.ts
+++ b/libs/mql-interpreter/test/backtest.test.ts
@@ -138,4 +138,15 @@ describe('BacktestRunner', () => {
     expect(gv.init).toBe(1);
     expect(gv.deinit).toBe(1);
   });
+
+  it('provides a backtest report', () => {
+    const code = 'void OnTick(){return;}';
+    const candles = [{ time: 1, open: 1, high: 1, low: 1, close: 1 }];
+    const runner = new BacktestRunner(code, candles);
+    runner.run();
+    const report = runner.getReport();
+    expect(report.globals.Bars).toBe(1);
+    expect(report.metrics.balance).toBe(0);
+    expect(report.orders.length).toBe(0);
+  });
 });

--- a/libs/mql-interpreter/test/basic.test.ts
+++ b/libs/mql-interpreter/test/basic.test.ts
@@ -11,6 +11,12 @@ describe('interpret', () => {
     expect(result.properties).toEqual({ copyright: ['"test"'] });
   });
 
+  it('stores execution context when provided', () => {
+    const ctx = { entryPoint: 'Print', args: ['hi'] };
+    const runtime = interpret('', ctx);
+    expect(runtime.context).toEqual(expect.objectContaining(ctx));
+  });
+
   it('compiles without executing', () => {
     const { runtime } = compile('input int A=1;');
     expect(runtime.variables.A.storage).toBe('input');

--- a/libs/mql-interpreter/test/builtins/common.test.ts
+++ b/libs/mql-interpreter/test/builtins/common.test.ts
@@ -15,6 +15,17 @@ import {
   ExpertRemove,
   DebugBreak,
   MessageBox,
+  TerminalCompany,
+  TerminalName,
+  TerminalPath,
+  IsConnected,
+  IsTesting,
+  IsOptimization,
+  IsVisualMode,
+  IsTradeAllowed,
+  IsTradeContextBusy,
+  IsDemo,
+  UninitializeReason,
   GlobalVariableSet,
   GlobalVariableGet,
   GlobalVariableDel,
@@ -24,6 +35,9 @@ import {
   GlobalVariableName,
   GlobalVariableTime,
   GlobalVariableSetOnCondition,
+  GlobalVariableTemp,
+  GlobalVariablesFlush,
+  WebRequest,
   setTerminal,
 } from "../../src/builtins/impl/common";
 import { builtinSignatures } from "../../src/builtins/signatures";
@@ -75,6 +89,20 @@ describe("common builtins", () => {
     expect(MessageBox("text")).toBe(1);
   });
 
+  it("terminal info helpers return defaults", () => {
+    expect(TerminalCompany()).toBe("MetaQuotes Software Corp.");
+    expect(TerminalName()).toBe("MetaTrader");
+    expect(TerminalPath()).toBe("");
+    expect(IsConnected()).toBe(true);
+    expect(IsTesting()).toBe(false);
+    expect(IsOptimization()).toBe(false);
+    expect(IsVisualMode()).toBe(false);
+    expect(IsDemo()).toBe(false);
+    expect(IsTradeAllowed()).toBe(true);
+    expect(IsTradeContextBusy()).toBe(false);
+    expect(UninitializeReason()).toBe(0);
+  });
+
   it("manages global variables", () => {
     GlobalVariablesDeleteAll();
     expect(GlobalVariablesTotal()).toBe(0);
@@ -90,6 +118,19 @@ describe("common builtins", () => {
     expect(GlobalVariableSetOnCondition("x", 7, 5)).toBe(false);
     expect(GlobalVariableDel("x")).toBe(true);
     expect(GlobalVariablesTotal()).toBe(0);
+    GlobalVariableSet("pref_y", 1);
+    GlobalVariableSet("pref_z", 1);
+    expect(GlobalVariablesDeleteAll("pref_")).toBe(2);
+  });
+
+  it("misc helpers handle requests and flush", () => {
+    const res = { value: "foo" };
+    expect(WebRequest("GET", "http://example.com", ["h"], "", 1000, res)).toBe(-1);
+    expect(res.value).toBe("");
+    GlobalVariableSet("tmp", 1);
+    GlobalVariableTemp("tmp", 2);
+    expect(GlobalVariableGet("tmp")).toBe(2);
+    expect(GlobalVariablesFlush()).toBe(0);
   });
 });
 

--- a/libs/mql-interpreter/test/cli.test.ts
+++ b/libs/mql-interpreter/test/cli.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { mkdtempSync, writeFileSync, readFileSync } from 'fs';
+import { tmpdir } from 'os';
+import path from 'path';
+import { spawnSync, execSync } from 'child_process';
+
+const libDir = path.resolve(__dirname, '..');
+const bin = path.join(libDir, 'bin', 'mql-interpreter.js');
+
+describe('CLI backtest', () => {
+  it('runs backtest and stores globals', () => {
+    execSync('npm run build --silent', { cwd: libDir });
+    const dir = mkdtempSync(path.join(tmpdir(), 'mt4-'));
+    const codePath = path.join(dir, 'test.mq4');
+    const csvPath = path.join(dir, 'data.csv');
+    writeFileSync(codePath, 'string name="x"; void OnTick(){ GlobalVariableSet(name, GlobalVariableGet(name)+1); }');
+    writeFileSync(csvPath, '1,1,1,1,1\n2,2,2,2,2\n3,3,3,3,3\n');
+    const res = spawnSync('node', [bin, codePath, '--backtest', csvPath, '--data-dir', dir], { encoding: 'utf8' });
+    const out = JSON.parse(res.stdout.trim());
+    expect(out.globals.Bars).toBe(3);
+    expect(out.metrics.balance).toBe(0);
+    const gv = JSON.parse(readFileSync(path.join(dir, 'MQL4', 'Files', 'globals.json'), 'utf8'));
+    expect(gv.x.value).toBe(3);
+  });
+
+  it('outputs html when requested', () => {
+    execSync('npm run build --silent', { cwd: libDir });
+    const dir = mkdtempSync(path.join(tmpdir(), 'mt4-'));
+    const codePath = path.join(dir, 'test.mq4');
+    const csvPath = path.join(dir, 'data.csv');
+    writeFileSync(codePath, 'void OnTick(){Print("ok");}');
+    writeFileSync(csvPath, '1,1,1,1,1\n');
+    const res = spawnSync('node', [bin, codePath, '--backtest', csvPath, '--format', 'html'], { encoding: 'utf8' });
+    expect(res.stdout.includes('<!doctype html>')).toBe(true);
+  });
+});

--- a/libs/mql-interpreter/test/runtime.test.ts
+++ b/libs/mql-interpreter/test/runtime.test.ts
@@ -163,6 +163,12 @@ describe('execute', () => {
     spy.mockRestore();
   });
 
+  it('stores execution context on the runtime', () => {
+    const ctx = { entryPoint: 'Print', args: ['x'] };
+    const runtime = execute([], ctx);
+    expect(runtime.context).toEqual(expect.objectContaining(ctx));
+  });
+
   it('throws when entry point missing', () => {
     expect(() => execute([], { entryPoint: 'Unknown' })).toThrow('Function Unknown not found');
   });


### PR DESCRIPTION
## Summary
- extend CLI backtest output with account metrics and order list
- expose `BacktestReport` via `BacktestRunner.getReport()`
- document new report structure in README
- test CLI output and new report helper

## Testing
- `npm test --silent --prefix libs/mql-interpreter`
- `npm run build --silent --prefix libs/mql-interpreter`
- `dotnet test api/stratrack-backend.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6885c651b5c883208fd25a9d83c61792