### PR TITLE
feat: support order modification in backtests

### DIFF
--- a/libs/mql-interpreter/src/backtest.ts
+++ b/libs/mql-interpreter/src/backtest.ts
@@ -456,6 +456,22 @@ export class BacktestRunner {
         if (pr) this.session.account.applyProfit(pr);
         return pr ? 1 : 0;
       },
+      OrderModify: (
+        ticket: number,
+        price: number,
+        sl: number,
+        tp: number,
+        _expiration?: number,
+        _arrowColor?: number
+      ) => {
+        const t = ticket >= 0 ? ticket : (this.selectedOrder?.ticket ?? -1);
+        if (t < 0) return 0;
+        const ok = this.session.broker.modify(t, price, sl, tp);
+        if (ok && this.selectedOrder && this.selectedOrder.ticket === t) {
+          this.selectedOrder = this.session.broker.getOrder(t);
+        }
+        return ok ? 1 : 0;
+      },
       AccountBalance: () => metrics().balance,
       AccountEquity: () => metrics().equity,
       AccountProfit: () => metrics().openProfit + metrics().closedProfit,

--- a/libs/mql-interpreter/src/broker.ts
+++ b/libs/mql-interpreter/src/broker.ts
@@ -118,6 +118,19 @@ export class Broker {
     return o.profit;
   }
 
+  modify(ticket: number, price: number, sl: number, tp: number): boolean {
+    const o = this.orders[ticket];
+    if (!o || o.state === "closed") return false;
+    if (o.state === "pending" && price > 0) {
+      o.price = price;
+    }
+    if (sl > 0) o.sl = sl;
+    else if (sl <= 0) o.sl = undefined;
+    if (tp > 0) o.tp = tp;
+    else if (tp <= 0) o.tp = undefined;
+    return true;
+  }
+
   getOpenOrders(): Order[] {
     return this.orders.filter((o) => o.state === "open");
   }

--- a/libs/mql-interpreter/test/backtest.test.ts
+++ b/libs/mql-interpreter/test/backtest.test.ts
@@ -68,6 +68,25 @@ describe("BacktestRunner", () => {
     expect(history[0].profit).toBeCloseTo(0.8); // 2 - 1.2
   });
 
+  it("modifies stop loss and take profit", () => {
+    const code = "void OnTick(){ return; }";
+    const candles = [
+      { time: 10, open: 1, high: 1.1, low: 1, close: 1 },
+      { time: 20, open: 1, high: 1.2, low: 0.7, close: 1 },
+    ];
+    const runner = new BacktestRunner(code, candles);
+    runner.step();
+    const rt = runner.getRuntime();
+    callFunction(rt, "OrderSend", ["", 0, 1, 0, 0, 0, 0]);
+    expect(runner.getBroker().getOpenOrders()[0].sl).toBeUndefined();
+    callFunction(rt, "OrderModify", [0, 0, 0.8, 0, 0, 0]);
+    expect(runner.getBroker().getOpenOrders()[0].sl).toBe(0.8);
+    runner.step();
+    const history = runner.getBroker().getHistory();
+    expect(history.length).toBe(1);
+    expect(history[0].closePrice).toBe(0.8);
+  });
+
   it("converts ticks to candles", () => {
     const ticks = [
       { time: 0, bid: 1, ask: 1 },


### PR DESCRIPTION
## Summary
- handle OrderModify in backtest builtins and broker
- ensure stop-loss and take-profit updates are applied during simulations
- add regression test for modifying orders

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688bbe98a5288320a39c8a8f18fe5b3d