### PR TITLE
feat(interpreter): format datetime output

### DIFF
--- a/libs/mql-interpreter/README.md
+++ b/libs/mql-interpreter/README.md
@@ -99,7 +99,7 @@ Others like `iMA`, `iMACD`, `iRSI` or `AccountBalance` depend on trading platfor
 default to no-ops. Host applications may provide real implementations by
 calling `registerEnvBuiltins()` before executing code.
 
-A generated list of builtin signatures is available in [BUILTIN_SIGNATURES.md](./BUILTIN_SIGNATURES.md) and can be refreshed with `npm run update-builtin-docs`. Run `mql-interpreter --list-builtins` to print the signatures from the CLI.
+A generated list of builtin signatures is available in [BUILTIN_SIGNATURES.md](./BUILTIN_SIGNATURES.md) and can be refreshed with `npm run update-builtin-docs`. Run `mql-interpreter --list-builtins` to print the signatures from the CLI or `--list-builtins-json` for a JSON dump.
 
 Global variable helpers described at
 <https://docs.mql4.com/globals> are included. Use functions such as
@@ -204,8 +204,8 @@ npx mql-interpreter path/to/file.mq4
 The CLI performs compilation first. Any warnings are printed but do not halt
 execution by default. Pass `--warnings-as-errors` to exit when warnings are
 present, `--suppress-warning <code>` to ignore specific warnings, `--list-warnings`
-to print the available warning codes with descriptions, or `--list-builtins` to list builtin
-function signatures. If syntax or type
+to print the available warning codes with descriptions, `--list-builtins` to list builtin
+function signatures, or `--list-builtins-json` to output them as JSON. If syntax or type
 errors are detected they are printed and the process exits with a
 non-zero status. When syntax errors occur, type checking is skipped to avoid
 redundant messages:

--- a/libs/mql-interpreter/TODO.md
+++ b/libs/mql-interpreter/TODO.md
@@ -67,7 +67,7 @@ The following tasks outline future work required to develop a functional MQL4/5 
 - [x] Add a CI check to ensure warning documentation is up to date.
 - [x] Auto-generate builtin signature documentation and verify it remains current.
   - [x] Expose builtin signatures via a CLI flag.
-  - [ ] Allow outputting builtin signatures in JSON form for easier machine consumption.
+  - [x] Allow outputting builtin signatures in JSON form for easier machine consumption.
   - [ ] Investigate generating builtin signature documentation at release time without relying on a checked-in `BUILTIN_SIGNATURES.md`.
 - [ ] Support `#pragma warning` directives to enable or disable diagnostics within source files.
 - [x] Support templates and class templates.

--- a/libs/mql-interpreter/bin/mql-interpreter.js
+++ b/libs/mql-interpreter/bin/mql-interpreter.js
@@ -17,6 +17,11 @@ if (args.includes("--list-warnings")) {
   }
   process.exit(0);
 }
+if (args.includes("--list-builtins-json")) {
+  const sigs = getBuiltinSignatures();
+  console.log(JSON.stringify(sigs, null, 2));
+  process.exit(0);
+}
 if (args.includes("--list-builtins")) {
   const sigs = getBuiltinSignatures();
   const names = Object.keys(sigs).sort();
@@ -37,7 +42,7 @@ if (args.includes("--list-builtins")) {
 const file = args.shift();
 if (!file) {
   console.error(
-    "Usage: mql-interpreter <file.mq4> [--backtest <data.csv>] [--data <data.csv>] [--data-dir <dir>] [--balance <amount>] [--margin <amount>] [--currency <code>] [--format html|json] [--warnings-as-errors] [--suppress-warning <code>] [--list-warnings] [--list-builtins]"
+    "Usage: mql-interpreter <file.mq4> [--backtest <data.csv>] [--data <data.csv>] [--data-dir <dir>] [--balance <amount>] [--margin <amount>] [--currency <code>] [--format html|json] [--warnings-as-errors] [--suppress-warning <code>] [--list-warnings] [--list-builtins] [--list-builtins-json]"
   );
   process.exit(1);
 }

--- a/libs/mql-interpreter/src/builtins/impl/common.ts
+++ b/libs/mql-interpreter/src/builtins/impl/common.ts
@@ -1,6 +1,8 @@
+// Import paths use explicit `.js` extensions to satisfy NodeNext module resolution.
 import type { BuiltinFunction } from "../types.js";
 import { formatString } from "./format.js";
 import type { VirtualTerminal } from "../../terminal.js";
+import { DateTimeValue } from "../../datetimeValue.js";
 
 let terminal: VirtualTerminal | null = null;
 export function setTerminal(t: VirtualTerminal | null): void {
@@ -12,8 +14,9 @@ export function getTerminal(): VirtualTerminal | null {
 }
 
 export const Print: BuiltinFunction = (...args: any[]) => {
-  if (terminal) return terminal.print(...args);
-  console.log(...args);
+  const formatted = args.map((a) => (a instanceof DateTimeValue ? a.toString() : a));
+  if (terminal) return terminal.print(...formatted);
+  console.log(...formatted);
   return 0;
 };
 

--- a/libs/mql-interpreter/src/builtins/impl/datetime.ts
+++ b/libs/mql-interpreter/src/builtins/impl/datetime.ts
@@ -1,6 +1,7 @@
 import type { BuiltinFunction } from "../types.js";
+import { DateTimeValue } from "../../datetimeValue.js";
 
-const toDate = (t?: number) => (t === undefined ? new Date() : new Date(t * 1000));
+const toDate = (t?: number) => (t === undefined ? new Date() : new Date(Number(t) * 1000));
 
 export const Day: BuiltinFunction = (t?: number) => toDate(t).getUTCDate();
 export const DayOfWeek: BuiltinFunction = (t?: number) => toDate(t).getUTCDay();
@@ -16,10 +17,12 @@ export const Month: BuiltinFunction = (t?: number) => toDate(t).getUTCMonth() + 
 export const Seconds: BuiltinFunction = (t?: number) => toDate(t).getUTCSeconds();
 export const Year: BuiltinFunction = (t?: number) => toDate(t).getUTCFullYear();
 
-export const TimeCurrent: BuiltinFunction = () => Math.floor(Date.now() / 1000);
-export const TimeLocal: BuiltinFunction = () => TimeCurrent() + TimeGMTOffset();
+const now = () => Math.floor(Date.now() / 1000);
+
+export const TimeCurrent: BuiltinFunction = () => new DateTimeValue(now());
+export const TimeLocal: BuiltinFunction = () => new DateTimeValue(now() + TimeGMTOffset());
 export const TimeGMT: BuiltinFunction = () =>
-  TimeDaylightSavings() === 0 ? TimeCurrent() : TimeCurrent() - 3600;
+  new DateTimeValue(TimeDaylightSavings() === 0 ? now() : now() - 3600);
 export const TimeDaylightSavings: BuiltinFunction = () => {
   // Get current time in UTC
   const utc = new Date().toLocaleString("en-US", {
@@ -62,7 +65,7 @@ export const StructToTime: BuiltinFunction = (s: {
   sec?: number;
 }) => {
   const date = new Date(s.year, (s.mon || 1) - 1, s.day, s.hour || 0, s.min || 0, s.sec || 0);
-  return Math.floor(date.getTime() / 1000);
+  return new DateTimeValue(Math.floor(date.getTime() / 1000));
 };
 
 export const TimeDay: BuiltinFunction = (t: number) => Day(t);

--- a/libs/mql-interpreter/src/casting.ts
+++ b/libs/mql-interpreter/src/casting.ts
@@ -1,3 +1,5 @@
+import { DateTimeValue } from "./datetimeValue.js";
+
 export type PrimitiveType =
   | "char"
   | "uchar"
@@ -33,8 +35,9 @@ export function cast(value: any, type: PrimitiveType): any {
     case "long":
     case "ulong":
     case "color":
-    case "datetime":
       return Number(value) | 0;
+    case "datetime":
+      return new DateTimeValue(Number(value) | 0);
     default:
       throw new Error(`Unknown cast target: ${type}`);
   }

--- a/libs/mql-interpreter/src/datetimeValue.ts
+++ b/libs/mql-interpreter/src/datetimeValue.ts
@@ -1,0 +1,13 @@
+export class DateTimeValue {
+  constructor(private readonly seconds: number) {}
+
+  valueOf(): number {
+    return this.seconds;
+  }
+
+  toString(): string {
+    const date = new Date(this.seconds * 1000);
+    const pad = (n: number) => n.toString().padStart(2, "0");
+    return `${date.getFullYear()}.${pad(date.getMonth() + 1)}.${pad(date.getDate())} ${pad(date.getHours())}:${pad(date.getMinutes())}:${pad(date.getSeconds())}`;
+  }
+}

--- a/libs/mql-interpreter/src/statements.ts
+++ b/libs/mql-interpreter/src/statements.ts
@@ -4,6 +4,7 @@
 import { lex, Token, TokenType } from "./lexer.js";
 import { evaluateExpression, EvalEnv } from "./expression.js";
 import type { Runtime } from "./runtime.js";
+import { cast, PrimitiveType } from "./casting.js";
 
 interface ExecResult {
   break?: boolean;
@@ -130,6 +131,7 @@ export function executeStatements(
 
     // variable declaration
     if (t.type === TokenType.Keyword && typeKeywords.has(t.value)) {
+      const type = t.value;
       consume(TokenType.Keyword);
       const name = consume(TokenType.Identifier).value;
       let val: any = undefined;
@@ -137,6 +139,11 @@ export function executeStatements(
         consume(TokenType.Operator, "=");
         const expr = readExpression(";");
         val = evaluateExpression(expr, env, runtime);
+        try {
+          val = cast(val, type as PrimitiveType);
+        } catch {
+          /* ignore */
+        }
       }
       consume(TokenType.Punctuation, ";");
       env[name] = val;

--- a/libs/mql-interpreter/test/builtins/common.test.ts
+++ b/libs/mql-interpreter/test/builtins/common.test.ts
@@ -40,10 +40,11 @@ import {
   WebRequest,
   setTerminal,
 } from "../../src/builtins/impl/common";
+import { StructToTime } from "../../src/builtins/impl/datetime";
 import { builtinSignatures } from "../../src/builtins/signatures";
 import { coreBuiltins, envBuiltins } from "../../src/builtins/impl";
 import { VirtualTerminal } from "../../src/terminal";
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 
 describe("common builtins", () => {
   beforeEach(() => {
@@ -53,6 +54,14 @@ describe("common builtins", () => {
   it("Print and Comment output and return 0", () => {
     expect(Print("a")).toBe(0);
     expect(Comment("b")).toBe(0);
+  });
+
+  it("Print formats datetime values", () => {
+    const spy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const t = StructToTime({ year: 2000, mon: 1, day: 2, hour: 3, min: 4, sec: 5 });
+    Print(t);
+    expect(spy).toHaveBeenCalledWith("2000.01.02 03:04:05");
+    spy.mockRestore();
   });
 
   it("Alert returns true", () => {

--- a/libs/mql-interpreter/test/builtins/datetime.test.ts
+++ b/libs/mql-interpreter/test/builtins/datetime.test.ts
@@ -65,6 +65,6 @@ describe("date/time builtins", () => {
 
   it("TimeToStruct and StructToTime round trip", () => {
     const s = TimeToStruct(0);
-    expect(StructToTime(s)).toBe(0);
+    expect(Number(StructToTime(s))).toBe(0);
   });
 });

--- a/libs/mql-interpreter/test/cli.test.ts
+++ b/libs/mql-interpreter/test/cli.test.ts
@@ -51,4 +51,12 @@ describe("cli options", () => {
     expect(lines.some((l) => l.startsWith("Print("))).toBe(true);
     expect(lines.some((l) => l.startsWith("ArrayResize("))).toBe(true);
   });
+
+  it("dumps builtin signatures as JSON", () => {
+    const result = spawnSync("node", [cli, "--list-builtins-json"], { cwd: root });
+    expect(result.status).toBe(0);
+    const json = JSON.parse(result.stdout.toString());
+    expect(json.Print).toBeDefined();
+    expect(json.ArrayResize).toBeDefined();
+  });
 });


### PR DESCRIPTION
## Summary
- keep datetime values with their type and print them formatted
- refactor DateTimeValue into a typed class
- add coverage for printing datetime values
- document why builtin imports use `.js` extensions
- allow CLI to output builtin signatures as JSON with `--list-builtins-json`
- mark JSON builtin signature output task as complete in TODO

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`


------
https://chatgpt.com/codex/tasks/task_e_689308fe2fe0832095027775ece85cb3