### PR TITLE
Rename backtest CLI option to --candles

### DIFF
--- a/libs/mql-interpreter/README.md
+++ b/libs/mql-interpreter/README.md
@@ -216,14 +216,14 @@ npx mql-interpreter bad.mq4
 1:1 Unknown type Foo
 ```
 
-To run a quick backtest, supply the `--backtest` option with candle data in CSV
+To run a quick backtest, supply the `--candles` option with candle data in CSV
 format. Optionally set `--data-dir` to mimic the MT4 data folder so global
 variables persist between runs. Results now include account metrics and the
 executed order list in addition to globals. Output is JSON by default or an
 HTML snippet when `--format html` is provided:
 
 ```bash
-npx mql-interpreter test.mq4 --backtest candles.csv --data-dir ./tmp --format html > report.html
+npx mql-interpreter test.mq4 --candles candles.csv --data-dir ./tmp --format html > report.html
 ```
 
 ## Architecture

--- a/libs/mql-interpreter/examples/README.md
+++ b/libs/mql-interpreter/examples/README.md
@@ -15,7 +15,7 @@ npm run build
 Run the bundled MACD sample expert advisor on sample GBPUSD data:
 
 ```bash
-node dist/cli.cjs backtest "examples/MACD Sample.mq4" --backtest examples/data/GBPUSD_M1.csv
+node dist/cli.cjs backtest "examples/MACD Sample.mq4" --candles examples/data/GBPUSD_M1.csv
 ```
 
 The command prints a JSON report containing global variables, account metrics and executed orders. By default the backtest runs with a 10,000&nbsp;USD balance; adjust account settings using `--balance`, `--margin` and `--currency` if needed. Replace the CSV file with history exported from MetaTrader to backtest your own data.

--- a/libs/mql-interpreter/src/cli.ts
+++ b/libs/mql-interpreter/src/cli.ts
@@ -26,16 +26,21 @@ program
   });
 
 program
-  .command("backtest <file>")
+  .command("backtest <file> [candles]")
   .description("バックテストを実行")
-  .requiredOption("--backtest <csv>", "ローソク足のCSVファイル")
+  .option("--candles <csv>", "ローソク足のCSVファイル")
   .option("--balance <balance>", "初期残高", (v) => Number(v))
   .option("--margin <margin>", "初期証拠金", (v) => Number(v))
   .option("--currency <code>", "口座通貨")
   .option("--timeframe <seconds>", "デフォルト時間足", (v) => Number(v))
-  .action((file: string, opts: any) => {
+  .action((file: string, candles: string | undefined, opts: any) => {
+    const csvFile = candles ?? opts.candles;
+    if (!csvFile) {
+      console.error("ローソク足のCSVファイルを指定してください");
+      process.exit(1);
+    }
     const code = readFileSync(file, "utf8");
-    const csv = readFileSync(opts.backtest, "utf8");
+    const csv = readFileSync(csvFile, "utf8");
     const data = parseCsv(csv);
     const runner = new BacktestRunner(code, data, {
       initialBalance: opts.balance,

--- a/libs/mql-interpreter/test/libs/cli.test.ts
+++ b/libs/mql-interpreter/test/libs/cli.test.ts
@@ -36,7 +36,7 @@ describe("cli", () => {
         cli,
         "backtest",
         codeFile,
-        "--backtest",
+        "--candles",
         csvFile,
         "--balance",
         "5000",


### PR DESCRIPTION
## Summary
- rename `--backtest` flag to `--candles`
- allow passing candle CSV as positional argument
- update docs and tests for `--candles` usage

## Testing
- `npm run format`
- `npm run lint`
- `npm run test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a1f3a459148320848d6f0328e7879f