### PR TITLE
feat(mql-interpreter): add publish workflow and npx support

### DIFF
--- a/.github/workflows/main_stratrack-dev-func.yml
+++ b/.github/workflows/main_stratrack-dev-func.yml
@@ -7,6 +7,8 @@ on:
   push:
     branches:
       - main
+    paths:
+      - 'api/**'
   workflow_dispatch:
 
 env:

--- a/.github/workflows/main_stratrack-dev-web.yml
+++ b/.github/workflows/main_stratrack-dev-web.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main  # デプロイ対象ブランチを指定
+    paths:
+      - 'frontend/**'
 
 permissions:
   id-token: write

--- a/.github/workflows/publish-mql-interpreter.yml
+++ b/.github/workflows/publish-mql-interpreter.yml
@@ -1,0 +1,27 @@
+name: Publish mql-interpreter
+
+on:
+  workflow_dispatch:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: libs/mql-interpreter
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: 'https://registry.npmjs.org'
+      - run: npm ci
+      - run: npm run lint
+      - run: npm test -- --run
+      - run: npm run build
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+

--- a/.github/workflows/publish-mql-interpreter.yml
+++ b/.github/workflows/publish-mql-interpreter.yml
@@ -1,12 +1,19 @@
-name: Publish mql-interpreter
+name: mql-interpreter CI
 
 on:
   workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'libs/mql-interpreter/**'
+  pull_request:
+    paths:
+      - 'libs/mql-interpreter/**'
   release:
     types: [published]
 
 jobs:
-  publish:
+  build:
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -21,7 +28,9 @@ jobs:
       - run: npm run lint
       - run: npm test -- --run
       - run: npm run build
-      - run: npm publish
+      - name: Publish
+        if: github.event_name == 'release'
+        run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/libs/mql-interpreter/README.md
+++ b/libs/mql-interpreter/README.md
@@ -204,6 +204,8 @@ file and print the resulting runtime information:
 
 ```bash
 npx mql-interpreter path/to/file.mq4
+# or use the shorter alias
+npx mqli path/to/file.mq4
 ```
 
 The CLI performs compilation first. Any warnings are printed but do not halt

--- a/libs/mql-interpreter/package.json
+++ b/libs/mql-interpreter/package.json
@@ -5,6 +5,9 @@
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
   "exports": {
     ".": {
       "import": "./dist/index.mjs",
@@ -13,6 +16,7 @@
     "./cli": "./dist/cli.cjs"
   },
   "bin": {
+    "mql-interpreter": "./dist/cli.cjs",
     "mqli": "./dist/cli.cjs"
   },
   "scripts": {
@@ -21,7 +25,8 @@
     "build": "tsup src/index.ts src/cli.ts --format cjs,esm,iife --dts",
     "dev": "tsup src/index.ts src/cli.ts --watch",
     "dev:cli": "tsx src/cli.ts",
-    "test": "vitest"
+    "test": "vitest",
+    "prepublishOnly": "npm run build"
   },
   "devDependencies": {
     "@eslint/js": "^9.33.0",


### PR DESCRIPTION
## Summary
- publish mql-interpreter to npm via GitHub Actions
- expose CLI for npx with mql-interpreter/mqli commands
- document npx usage

## Testing
- `npm run format`
- `npm run lint`
- `npm run test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a545c5c69883209a32f26b6369403e