### PR TITLE
Setup standalone mql-interpreter examples

### DIFF
--- a/libs/mql-interpreter/examples/README.md
+++ b/libs/mql-interpreter/examples/README.md
@@ -9,6 +9,14 @@ cd libs/mql-interpreter/examples
 npm install
 ```
 
+## Syntax Check
+
+Verify that the sample compiles without errors:
+
+```bash
+npx mqli check "MACD Sample.mq4"
+```
+
 ## CLI Backtest
 
 Run the bundled MACD sample expert advisor on sample GBPUSD data using the published package:

--- a/libs/mql-interpreter/examples/README.md
+++ b/libs/mql-interpreter/examples/README.md
@@ -5,42 +5,27 @@ This directory demonstrates how to run the interpreter from the command line and
 ## Setup
 
 ```bash
-cd libs/mql-interpreter
+cd libs/mql-interpreter/examples
 npm install
 ```
 
 ## CLI Backtest
 
-Run the bundled MACD sample expert advisor on sample GBPUSD data.
-
-### Development
-
-Execute the CLI directly without building:
+Run the bundled MACD sample expert advisor on sample GBPUSD data using the published package:
 
 ```bash
-npm run dev:cli -- backtest "examples/MACD Sample.mq4" --candles examples/data/GBPUSD_M1.csv
+npx mql-interpreter backtest "MACD Sample.mq4" --candles data/GBPUSD_M1.csv
 ```
 
-### Built
-
-After building the package:
-
-```bash
-npm run build
-node dist/cli.cjs backtest "examples/MACD Sample.mq4" --candles examples/data/GBPUSD_M1.csv
-```
-
-Both commands print a JSON report containing global variables, account metrics and executed orders. By default the backtest runs with a 10,000\u00a0USD balance; adjust account settings using `--balance`, `--margin` and `--currency` if needed. Replace the CSV file with history exported from MetaTrader to backtest your own data.
+The command prints a JSON report containing global variables, account metrics and executed orders. By default the backtest runs with a 10,000\u00a0USD balance; adjust account settings using `--balance`, `--margin` and `--currency` if needed. Replace the CSV file with history exported from MetaTrader to backtest your own data.
 
 The sample dataset uses the `date,time,open,high,low,close,volume` format where `date` is formatted as `YYYY.MM.DD` and `time` is formatted as `HH:MI`. To reproduce a live environment, export MetaTrader history in this format and place it under `examples/data/`.
 
 ## Browser Backtest
 
-After building the package you can run a backtest directly in a browser. Because the Web Worker imports the compiled interpreter
-from `dist/index.js`, the static server must expose the package root. Serve this directory and then open `examples/browser-backtest.html`:
+Serve this directory and then open `browser-backtest.html` to run a backtest directly in a browser. The Web Worker imports the interpreter from `node_modules`:
 
 ```bash
-npm run build
 npx serve . # or python -m http.server
 ```
 

--- a/libs/mql-interpreter/examples/browser-backtest-worker.js
+++ b/libs/mql-interpreter/examples/browser-backtest-worker.js
@@ -1,5 +1,5 @@
-// Import the built interpreter; ensure the static server exposes `dist/index.js` relative to this file.
-import { BacktestRunner, parseCsv } from "../dist/index.js";
+// Import the interpreter from node_modules.
+import { BacktestRunner, parseCsv } from "./node_modules/mql-interpreter/dist/index.js";
 
 const PERIODS = {
   M1: 60,

--- a/libs/mql-interpreter/examples/package-lock.json
+++ b/libs/mql-interpreter/examples/package-lock.json
@@ -1,0 +1,25 @@
+{
+  "name": "examples",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "examples",
+      "version": "1.0.0",
+      "license": "ISC",
+      "dependencies": {
+        "mql-interpreter": "^0.1.0"
+      }
+    },
+    "node_modules/mql-interpreter": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/mql-interpreter/-/mql-interpreter-0.1.0.tgz",
+      "integrity": "sha512-BJCToPIqNlRtT4ReTU4HtHP8T1VZ6rpwRUtCB36fd9mEqOpwiyKeKzJ7hQUAQvAqv1c26pYpDn8UCSOll9+CFg==",
+      "bin": {
+        "mql-interpreter": "dist/cli.cjs",
+        "mqli": "dist/cli.cjs"
+      }
+    }
+  }
+}

--- a/libs/mql-interpreter/examples/package.json
+++ b/libs/mql-interpreter/examples/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "examples",
+  "version": "1.0.0",
+  "description": "This directory demonstrates how to run the interpreter from the command line and how to verify indicator calculations against reference values.",
+  "main": "browser-backtest-worker.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "module",
+  "dependencies": {
+    "mql-interpreter": "^0.1.0"
+  }
+}

--- a/libs/mql-interpreter/src/libs/signatures/common.ts
+++ b/libs/mql-interpreter/src/libs/signatures/common.ts
@@ -75,12 +75,15 @@ export const commonBuiltinSignatures: BuiltinSignaturesMap = {
     description: "Plays a sound file",
   },
   Print: {
-    args: [{ name: "message", type: "string", optional: false }],
+    args: [{ name: "args", type: "any", variadic: true }],
     returnType: "void",
     description: "Displays a message in the log",
   },
   PrintFormat: {
-    args: [{ name: "format", type: "string", optional: false }],
+    args: [
+      { name: "format", type: "string" },
+      { name: "args", type: "any", variadic: true },
+    ],
     returnType: "void",
     description:
       "Formats and prints the sets of symbols and values in a log file in accordance with a preset format",

--- a/libs/mql-interpreter/test/runtime/expression.test.ts
+++ b/libs/mql-interpreter/test/runtime/expression.test.ts
@@ -68,4 +68,10 @@ describe("evaluateExpression", () => {
     const found = bad.errors.some((e) => e.message.includes("Incorrect argument count"));
     expect(found).toBe(true);
   });
+
+  it("allows variadic Print arguments", () => {
+    const result = buildProgram('void start(){ Print("x", 1, "y"); }');
+    const found = result.errors.some((e) => e.message.includes("Incorrect argument count"));
+    expect(found).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- init `examples` folder as its own Node package and depend on published `mql-interpreter`
- load interpreter from `node_modules` in browser worker
- update example README for package-based usage

## Testing
- `npm run format`
- `npm run lint`
- `npm run test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a56da346f8832083ad89e9d47e1b6a