### PR TITLE
feat: handle integer overflow with BigInt

### DIFF
--- a/libs/mql-interpreter/package-lock.json
+++ b/libs/mql-interpreter/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mql-interpreter",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mql-interpreter",
-      "version": "0.1.1",
+      "version": "0.1.2",
       "bin": {
         "mql-interpreter": "dist/cli.cjs",
         "mqli": "dist/cli.cjs"

--- a/libs/mql-interpreter/package.json
+++ b/libs/mql-interpreter/package.json
@@ -22,8 +22,8 @@
   "scripts": {
     "format": "prettier --write .",
     "lint": "eslint .",
-    "build": "tsup src/index.ts src/cli.ts --format cjs,esm,iife --dts",
-    "dev": "tsup src/index.ts src/cli.ts --watch",
+    "build": "tsup src/index.ts src/cli.ts --format cjs,esm,iife --target es2020 --dts",
+    "dev": "tsup src/index.ts src/cli.ts --target es2020 --watch",
     "dev:cli": "tsx src/cli.ts",
     "test": "vitest",
     "prepublishOnly": "npm run build"

--- a/libs/mql-interpreter/src/runtime/casting.ts
+++ b/libs/mql-interpreter/src/runtime/casting.ts
@@ -1,4 +1,5 @@
 import { DateTimeValue } from "./datetimeValue";
+import { toInt32, toUInt32, toInt64, toUInt64 } from "./intMath";
 
 export type PrimitiveType =
   | "char"
@@ -27,17 +28,20 @@ export function cast(value: any, type: PrimitiveType): any {
     case "double":
       return Number(value);
     case "char":
-    case "uchar":
     case "short":
-    case "ushort":
     case "int":
-    case "uint":
-    case "long":
-    case "ulong":
     case "color":
-      return Number(value) | 0;
+      return toInt32(value);
+    case "uchar":
+    case "ushort":
+    case "uint":
+      return toUInt32(value);
+    case "long":
+      return toInt64(value);
+    case "ulong":
+      return toUInt64(value);
     case "datetime":
-      return new DateTimeValue(Number(value) | 0);
+      return new DateTimeValue(Number(toInt64(value)));
     default:
       throw new Error(`Unknown cast target: ${type}`);
   }

--- a/libs/mql-interpreter/src/runtime/expression.ts
+++ b/libs/mql-interpreter/src/runtime/expression.ts
@@ -4,11 +4,12 @@ export interface EvalEnv {
 
 import { lex, Token, TokenType } from "../parser/lexer";
 import { cast } from "./casting";
-import { DateTimeValue } from "./datetimeValue";
+import { intBinaryOp } from "./intMath";
 
 interface EvalResult {
   value: any;
   ref?: string;
+  type?: string;
 }
 
 // Operators for assignment
@@ -23,6 +24,33 @@ export function evaluateExpression(expr: string, env: EvalEnv = {}, runtime?: Ru
     throw new Error(errors.map((e) => e.message).join("\n"));
   }
   let pos = 0;
+
+  const intTypes = new Set([
+    "char",
+    "uchar",
+    "short",
+    "ushort",
+    "int",
+    "uint",
+    "long",
+    "ulong",
+    "bool",
+    "color",
+    "datetime",
+  ]);
+  const unsignedTypes = new Set(["uchar", "ushort", "uint", "ulong"]);
+
+  const getIntInfo = (r: EvalResult): { bits: 32 | 64; unsigned: boolean } | undefined => {
+    if (r.type) {
+      if (!intTypes.has(r.type)) return undefined;
+      const bits = r.type === "long" || r.type === "ulong" || r.type === "datetime" ? 64 : 32;
+      return { bits, unsigned: unsignedTypes.has(r.type) };
+    }
+    if (typeof r.value === "bigint") return { bits: 64, unsigned: false };
+    if (typeof r.value === "number" && Number.isInteger(r.value))
+      return { bits: 32, unsigned: false };
+    return undefined;
+  };
 
   const peek = () => tokens[pos];
   const atEnd = () => pos >= tokens.length;
@@ -40,7 +68,14 @@ export function evaluateExpression(expr: string, env: EvalEnv = {}, runtime?: Ru
     if (!t) throw new Error("Unexpected end");
     if (t.type === TokenType.Number) {
       consume();
-      return { value: Number(t.value) };
+      if (t.value.includes(".") || t.value.includes("e") || t.value.includes("E")) {
+        return { value: Number(t.value), type: "double" };
+      }
+      const bi = BigInt(t.value);
+      if (bi >= -2147483648n && bi <= 2147483647n) {
+        return { value: Number(bi), type: "int" };
+      }
+      return { value: bi, type: "long" };
     }
     if (t.type === TokenType.String) {
       consume();
@@ -48,11 +83,12 @@ export function evaluateExpression(expr: string, env: EvalEnv = {}, runtime?: Ru
     }
     if (t.type === TokenType.Keyword && (t.value === "true" || t.value === "false")) {
       consume();
-      return { value: t.value === "true" ? 1 : 0 };
+      return { value: t.value === "true" ? 1 : 0, type: "bool" };
     }
     if (t.type === TokenType.Identifier) {
       consume();
       const name = t.value;
+      const vtype = runtime?.variables[name]?.type;
       if (!atEnd() && peek().value === "(") {
         if (!runtime) throw new Error("Runtime required for function call");
         consume(TokenType.Punctuation, "(");
@@ -71,7 +107,7 @@ export function evaluateExpression(expr: string, env: EvalEnv = {}, runtime?: Ru
         consume(TokenType.Punctuation, ")");
         return { value: callFunction(runtime, name, args) };
       }
-      return { value: env[name], ref: name };
+      return { value: env[name], ref: name, type: vtype };
     }
     if (t.type === TokenType.Keyword && t.value === "new") {
       consume(TokenType.Keyword, "new");
@@ -95,9 +131,17 @@ export function evaluateExpression(expr: string, env: EvalEnv = {}, runtime?: Ru
       if (!result.ref) throw new Error("Invalid operand for " + op);
       const name = result.ref;
       const old = env[name] ?? 0;
-      if (op === "++") env[name] = old + 1;
-      else env[name] = old - 1;
-      result = { value: old };
+      const varType = runtime?.variables[name]?.type;
+      if (varType && intTypes.has(varType)) {
+        const info = getIntInfo({ value: old, type: varType })!;
+        const step = op === "++" ? 1 : -1;
+        const val = intBinaryOp("+", old, step, info.bits, info.unsigned);
+        env[name] = cast(val, varType as any);
+      } else {
+        if (op === "++") env[name] = old + 1;
+        else env[name] = old - 1;
+      }
+      result = { value: old, type: varType, ref: name };
     }
     return result;
   }
@@ -111,9 +155,17 @@ export function evaluateExpression(expr: string, env: EvalEnv = {}, runtime?: Ru
         if (!res.ref) throw new Error("Invalid operand for " + op);
         const name = res.ref;
         const val = env[name] ?? 0;
-        if (op === "++") env[name] = val + 1;
-        else env[name] = val - 1;
-        return { value: env[name] };
+        const varType = runtime?.variables[name]?.type;
+        if (varType && intTypes.has(varType)) {
+          const info = getIntInfo({ value: val, type: varType })!;
+          const step = op === "++" ? 1 : -1;
+          const v = intBinaryOp("+", val, step, info.bits, info.unsigned);
+          env[name] = cast(v, varType as any);
+        } else {
+          if (op === "++") env[name] = val + 1;
+          else env[name] = val - 1;
+        }
+        return { value: env[name], type: varType };
       }
       if (
         t.type === TokenType.Operator &&
@@ -149,27 +201,79 @@ export function evaluateExpression(expr: string, env: EvalEnv = {}, runtime?: Ru
       while (!atEnd() && peek().type === TokenType.Operator && ops.has(peek().value)) {
         const op = consume(TokenType.Operator).value;
         const right = nextFn();
+        const lInfo = getIntInfo(left);
+        const rInfo = getIntInfo(right);
+        const useInt = lInfo && rInfo;
+        const bits = useInt && (lInfo.bits === 64 || rInfo.bits === 64) ? 64 : 32;
+        const unsigned = Boolean(lInfo?.unsigned || rInfo?.unsigned);
         switch (op) {
           case "*":
-            left = { value: left.value * right.value };
-            break;
           case "/":
-            left = { value: left.value / right.value };
-            break;
           case "%":
-            left = { value: left.value % right.value };
-            break;
           case "+":
-            left = { value: left.value + right.value };
-            break;
           case "-":
-            left = { value: left.value - right.value };
-            break;
           case "<<":
-            left = { value: left.value << right.value };
-            break;
           case ">>":
-            left = { value: left.value >> right.value };
+          case "&":
+          case "^":
+          case "|":
+            if (useInt) {
+              const resultType =
+                left.type === "datetime" || right.type === "datetime"
+                  ? "datetime"
+                  : bits === 64
+                    ? unsigned
+                      ? "ulong"
+                      : "long"
+                    : unsigned
+                      ? "uint"
+                      : "int";
+              left = {
+                value: intBinaryOp(op, left.value, right.value, bits, unsigned),
+                type: resultType,
+              };
+            } else {
+              let value;
+              switch (op) {
+                case "*":
+                  value = left.value * right.value;
+                  break;
+                case "/":
+                  value = left.value / right.value;
+                  break;
+                case "%":
+                  value = left.value % right.value;
+                  break;
+                case "+":
+                  value = left.value + right.value;
+                  break;
+                case "-":
+                  value = left.value - right.value;
+                  break;
+                case "<<":
+                  value = left.value << right.value;
+                  break;
+                case ">>":
+                  value = left.value >> right.value;
+                  break;
+                case "&":
+                  value = left.value & right.value;
+                  break;
+                case "^":
+                  value = left.value ^ right.value;
+                  break;
+                case "|":
+                  value = left.value | right.value;
+                  break;
+              }
+              const resultType =
+                left.type === "double" || right.type === "double"
+                  ? "double"
+                  : left.type === "float" || right.type === "float"
+                    ? "float"
+                    : undefined;
+              left = { value, type: resultType };
+            }
             break;
           case "<":
             left = { value: left.value < right.value };
@@ -188,15 +292,6 @@ export function evaluateExpression(expr: string, env: EvalEnv = {}, runtime?: Ru
             break;
           case "!=":
             left = { value: left.value != right.value };
-            break;
-          case "&":
-            left = { value: left.value & right.value };
-            break;
-          case "^":
-            left = { value: left.value ^ right.value };
-            break;
-          case "|":
-            left = { value: left.value | right.value };
             break;
           case "&&":
             left = { value: left.value && right.value };
@@ -240,47 +335,51 @@ export function evaluateExpression(expr: string, env: EvalEnv = {}, runtime?: Ru
       if (!left.ref) throw new Error("Invalid assignment target");
       const right = parseAssignment();
       const oldVal = env[left.ref] ?? 0;
+      const varType = runtime?.variables[left.ref]?.type as string | undefined;
       let newVal;
-      switch (op) {
-        case "=":
-          newVal = right.value;
-          break;
-        case "+=":
-          newVal = oldVal + right.value;
-          break;
-        case "-=":
-          newVal = oldVal - right.value;
-          break;
-        case "*=":
-          newVal = oldVal * right.value;
-          break;
-        case "/=":
-          newVal = oldVal / right.value;
-          break;
-        case "%=":
-          newVal = oldVal % right.value;
-          break;
-        case "&=":
-          newVal = oldVal & right.value;
-          break;
-        case "|=":
-          newVal = oldVal | right.value;
-          break;
-        case "^=":
-          newVal = oldVal ^ right.value;
-          break;
-        case "<<=":
-          newVal = oldVal << right.value;
-          break;
-        case ">>=":
-          newVal = oldVal >> right.value;
-          break;
+      if (op === "=") {
+        newVal = right.value;
+      } else if (varType && intTypes.has(varType)) {
+        const info = getIntInfo({ value: oldVal, type: varType })!;
+        const baseOp = op.slice(0, -1);
+        const rVal = cast(right.value, varType as any);
+        newVal = intBinaryOp(baseOp, oldVal, rVal, info.bits, info.unsigned);
+      } else {
+        switch (op) {
+          case "+=":
+            newVal = oldVal + right.value;
+            break;
+          case "-=":
+            newVal = oldVal - right.value;
+            break;
+          case "*=":
+            newVal = oldVal * right.value;
+            break;
+          case "/=":
+            newVal = oldVal / right.value;
+            break;
+          case "%=":
+            newVal = oldVal % right.value;
+            break;
+          case "&=":
+            newVal = oldVal & right.value;
+            break;
+          case "|=":
+            newVal = oldVal | right.value;
+            break;
+          case "^=":
+            newVal = oldVal ^ right.value;
+            break;
+          case "<<=":
+            newVal = oldVal << right.value;
+            break;
+          case ">>=":
+            newVal = oldVal >> right.value;
+            break;
+        }
       }
-      const isDate =
-        (runtime && runtime.variables[left.ref]?.type === "datetime") ||
-        oldVal instanceof DateTimeValue;
-      env[left.ref] = isDate ? cast(newVal, "datetime") : newVal;
-      left = { value: env[left.ref] };
+      env[left.ref] = varType ? cast(newVal, varType as any) : newVal;
+      left = { value: env[left.ref], type: varType };
     }
     return left;
   }

--- a/libs/mql-interpreter/src/runtime/intMath.ts
+++ b/libs/mql-interpreter/src/runtime/intMath.ts
@@ -1,0 +1,65 @@
+const toBigInt = (value: any): bigint => {
+  if (typeof value === "bigint") return value;
+  return BigInt(Math.trunc(Number(value)));
+};
+
+export function toInt32(value: any): number {
+  return Number(BigInt.asIntN(32, toBigInt(value)));
+}
+
+export function toUInt32(value: any): number {
+  return Number(BigInt.asUintN(32, toBigInt(value)));
+}
+
+export function toInt64(value: any): bigint {
+  return BigInt.asIntN(64, toBigInt(value));
+}
+
+export function toUInt64(value: any): bigint {
+  return BigInt.asUintN(64, toBigInt(value));
+}
+
+export function intBinaryOp(op: string, a: any, b: any, bits: 32 | 64, unsigned = false): any {
+  const A = BigInt(a);
+  const B = BigInt(b);
+  let result: bigint;
+  switch (op) {
+    case "+":
+      result = A + B;
+      break;
+    case "-":
+      result = A - B;
+      break;
+    case "*":
+      result = A * B;
+      break;
+    case "/":
+      result = B === 0n ? 0n : A / B;
+      break;
+    case "%":
+      result = B === 0n ? 0n : A % B;
+      break;
+    case "<<":
+      result = A << B;
+      break;
+    case ">>":
+      result = A >> B;
+      break;
+    case "&":
+      result = A & B;
+      break;
+    case "|":
+      result = A | B;
+      break;
+    case "^":
+      result = A ^ B;
+      break;
+    default:
+      throw new Error(`Unsupported op ${op}`);
+  }
+  if (bits === 32) {
+    return unsigned ? toUInt32(result) : toInt32(result);
+  } else {
+    return unsigned ? toUInt64(result) : toInt64(result);
+  }
+}

--- a/libs/mql-interpreter/test/runtime/integerOverflow.test.ts
+++ b/libs/mql-interpreter/test/runtime/integerOverflow.test.ts
@@ -1,0 +1,51 @@
+import { evaluateExpression } from "../../src/runtime/expression";
+import { describe, it, expect } from "vitest";
+import { DateTimeValue } from "../../src/runtime/datetimeValue";
+import type { RuntimeState } from "../../src/runtime/types";
+
+describe("integer overflow", () => {
+  it("wraps 32-bit int overflow", () => {
+    const result = evaluateExpression("2147483647 + 1");
+    expect(result).toBe(-2147483648);
+  });
+
+  it("wraps 64-bit long overflow", () => {
+    const result = evaluateExpression("9223372036854775807 + 1");
+    expect(result).toBe(-9223372036854775808n);
+  });
+
+  it("mixes int and double without overflow", () => {
+    const result = evaluateExpression("2147483647 + 0.5");
+    expect(result).toBe(2147483647.5);
+  });
+
+  it("handles compound assignment with float operand", () => {
+    const env: any = { i: 1 };
+    const runtime = {
+      enums: {},
+      classes: {},
+      functions: {},
+      variables: { i: { type: "int", dimensions: [] } },
+      properties: {},
+      staticLocals: {},
+      globalValues: {},
+    } as RuntimeState;
+    evaluateExpression("i += 2.5", env, runtime);
+    expect(env.i).toBe(3);
+  });
+
+  it("supports datetime arithmetic without overflow", () => {
+    const env: any = { t: new DateTimeValue(2147483647) };
+    const runtime = {
+      enums: {},
+      classes: {},
+      functions: {},
+      variables: { t: { type: "datetime", dimensions: [] } },
+      properties: {},
+      staticLocals: {},
+      globalValues: {},
+    } as RuntimeState;
+    evaluateExpression("t += 1", env, runtime);
+    expect(env.t.valueOf()).toBe(2147483648);
+  });
+});

--- a/libs/mql-interpreter/tsconfig.json
+++ b/libs/mql-interpreter/tsconfig.json
@@ -11,7 +11,7 @@
     // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
 
     /* Language and Environment */
-    "target": "es2019" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
+    "target": "es2020" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
     "lib": ["es2020"],
     "moduleResolution": "bundler",
     "types": ["node"],


### PR DESCRIPTION
## Summary
- add `intMath` module for 32/64-bit integer conversions and wrap-around arithmetic
- use `intMath` in casting and expression evaluation to preserve 64-bit precision
- refine expression logic to avoid treating floats/doubles as ints and include datetime operations
- add overflow and mixed-type tests
- target ES2020 and configure build to prevent BigInt warnings

## Testing
- `npm run format`
- `npm run lint`
- `npm run test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a6c9553aa48320a9fd14d2cf0f5bde