### PR TITLE
Sync indicator buffers with runtime

### DIFF
--- a/libs/mql-interpreter/src/backtestRunner.ts
+++ b/libs/mql-interpreter/src/backtestRunner.ts
@@ -209,6 +209,7 @@ export class BacktestRunner {
       getStopFlag: () => this.runtime.globalValues._StopFlag,
       indicatorEngine: this.indicatorEngine,
     };
+    this.context.runtime = this.runtime;
     this.initializeGlobals();
     const libs = createLibs(this.context);
     Object.defineProperties(this.context, {
@@ -287,6 +288,7 @@ export class BacktestRunner {
       callFunction(this.runtime, entry);
       this.index = this.candles.length;
       this.callDeinit();
+      this.runtime.globalValues._IndicatorBuffers = this.context.indicatorBuffers;
       return;
     }
     if (this.index >= this.candles.length) return;
@@ -325,6 +327,7 @@ export class BacktestRunner {
     }
     this.index++;
     if (this.index >= this.candles.length) this.callDeinit();
+    this.runtime.globalValues._IndicatorBuffers = this.context.indicatorBuffers;
   }
 
   run(): void {

--- a/libs/mql-interpreter/src/libs/domain/types.ts
+++ b/libs/mql-interpreter/src/libs/domain/types.ts
@@ -33,4 +33,6 @@ export interface ExecutionContext {
   indexStyles?: Record<number, { style: number; width: number; color: number }>;
   levelStyles?: Record<number, { style: number; width: number; color: number }>;
   levelValues?: Record<number, number>;
+  /** Runtime reference for syncing global indicator buffers */
+  runtime?: { globalValues: Record<string, any> };
 }

--- a/libs/mql-interpreter/src/libs/functions/customind.ts
+++ b/libs/mql-interpreter/src/libs/functions/customind.ts
@@ -27,6 +27,9 @@ export function createCustomInd(context: ExecutionContext): Record<string, Built
     // インジケーターバッファーのメモリ割り当て
     IndicatorBuffers: (count: number) => {
       context.indicatorBuffers = new Array(count).fill(null).map(() => []);
+      if (context.runtime) {
+        context.runtime.globalValues._IndicatorBuffers = context.indicatorBuffers;
+      }
       return;
     },
 
@@ -102,6 +105,9 @@ export function createCustomInd(context: ExecutionContext): Record<string, Built
     SetIndexBuffer: (index: number, buffer: number[]) => {
       if (index >= 0 && index < context.indicatorBuffers!.length) {
         context.indicatorBuffers![index] = buffer;
+        if (context.runtime) {
+          context.runtime.globalValues._IndicatorBuffers = context.indicatorBuffers;
+        }
       }
       return;
     },

--- a/libs/mql-interpreter/test/libs/functions/indicators.test.ts
+++ b/libs/mql-interpreter/test/libs/functions/indicators.test.ts
@@ -120,10 +120,23 @@ describe("indicators functions", () => {
   });
 
   describe("iCustom", () => {
-    it("should return 0 for custom indicators", () => {
+    it("returns 0 when indicator is not found", () => {
+      const functions = createIndicators(context);
+      const result = functions.iCustom("GBPUSD", 15, "Missing", 0, 0);
+      expect(result).toBe(0);
+    });
+
+    it("retrieves values from custom indicator", () => {
+      context.indicatorEngine!.set(
+        "TestIndicator",
+        `
+int OnInit(){IndicatorBuffers(1);SetIndexBuffer(0,Close);return 0;}
+int OnCalculate(){return Bars;}
+`
+      );
       const functions = createIndicators(context);
       const result = functions.iCustom("GBPUSD", 15, "TestIndicator", 0, 0);
-      expect(result).toBe(0);
+      expect(result).toBeCloseTo(1.25, 4);
     });
   });
 


### PR DESCRIPTION
## Summary
- sync indicator buffer allocation with runtime global storage
- persist custom indicator buffers to runtime after each backtest step
- verify iCustom retrieves values from custom indicators

## Testing
- `npm run lint`
- `npm run test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa0b6167d88320a4e8197001d5c098