### PR TITLE
feat: share market data and indicator cache across iCustom runners

### DIFF
--- a/libs/mql-interpreter/src/libs/domain/indicator/indicatorEngine.ts
+++ b/libs/mql-interpreter/src/libs/domain/indicator/indicatorEngine.ts
@@ -5,15 +5,16 @@ export interface IndicatorEngine {
   getSource(name: string): string | undefined;
   getOrCreate<T extends { last: number }>(key: IndicatorKey, init: () => T): T;
   peek<T extends { last: number }>(key: IndicatorKey): T | undefined;
+  getCache(): IndicatorCache;
 }
 
 export class InMemoryIndicatorEngine implements IndicatorEngine {
   private cache: IndicatorCache;
   public source: InMemoryIndicatorSource;
 
-  constructor(source?: InMemoryIndicatorSource) {
+  constructor(source?: InMemoryIndicatorSource, cache?: IndicatorCache) {
     this.source = source ?? new InMemoryIndicatorSource();
-    this.cache = new IndicatorCache();
+    this.cache = cache ?? new IndicatorCache();
   }
 
   getSource(name: string): string | undefined {
@@ -30,5 +31,9 @@ export class InMemoryIndicatorEngine implements IndicatorEngine {
 
   peek<T extends { last: number }>(key: IndicatorKey): T | undefined {
     return this.cache.peek(key);
+  }
+
+  getCache(): IndicatorCache {
+    return this.cache;
   }
 }

--- a/libs/mql-interpreter/src/libs/functions/indicators.ts
+++ b/libs/mql-interpreter/src/libs/functions/indicators.ts
@@ -1,7 +1,8 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import type { ExecutionContext } from "../domain/types";
 import type { BuiltinFunction } from "./types";
-import type { Candle } from "../domain/marketData";
+import type { Candle, InMemoryMarketData as MarketData } from "../domain/marketData";
+import type { InMemoryTerminal as VirtualTerminal } from "../domain/terminal";
 import { BacktestRunner } from "../../backtestRunner";
 
 export function createIndicators(context: ExecutionContext): Record<string, BuiltinFunction> {
@@ -278,6 +279,9 @@ export function createIndicators(context: ExecutionContext): Record<string, Buil
           symbol: sym && String(sym).length ? sym : undefined,
           timeframe: tf,
           indicatorEngine: engine,
+          market: context.market as MarketData,
+          indicatorCache: engine.getCache(),
+          terminal: context.terminal as VirtualTerminal,
         }),
       }));
 


### PR DESCRIPTION
## Summary
- allow BacktestRunner to reuse existing market data, indicator cache, and terminal
- pass market data, cache, and terminal when creating BacktestRunner inside iCustom
- verify nested iCustom calls share data and cache

## Testing
- `npm run lint`
- `npm run test -- --run`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa0f49dbe08320b270dae1d36e7ae6