### PR TITLE
feat(frontend): fetch market data from API

### DIFF
--- a/frontend/src/features/datasources/ChartDataProvider.tsx
+++ b/frontend/src/features/datasources/ChartDataProvider.tsx
@@ -14,6 +14,7 @@ export type ChartDataContextValue = {
   isLoading: boolean;
   error: string | null;
   handleRangeChange: (range: Range) => Promise<void>;
+  symbol: string;
 };
 
 const ChartDataContext = createContext<ChartDataContextValue | null>(null);
@@ -38,6 +39,7 @@ export const ChartDataProvider = ({
   const [dsRange, setDsRange] = useState<Range | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [symbol, setSymbol] = useState("");
 
   const loadData = useCallback(
     async (fromMs: number, toMs: number): Promise<Candle[]> => {
@@ -103,6 +105,7 @@ export const ChartDataProvider = ({
     setIsLoading(true);
     getDataSource(dataSourceId)
       .then(async (ds) => {
+        setSymbol(ds.symbol);
         if (ds.startTime && ds.endTime) {
           const end = new Date(ds.endTime).getTime();
           const start = ds.startTime ? new Date(ds.startTime).getTime() : end;
@@ -162,6 +165,7 @@ export const ChartDataProvider = ({
         isLoading,
         error,
         handleRangeChange,
+        symbol,
       }}
     >
       {children}

--- a/frontend/src/routes/datasources/chart.tsx
+++ b/frontend/src/routes/datasources/chart.tsx
@@ -1,12 +1,56 @@
+import { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
-import CandlestickChart from "../../components/CandlestickChart";
+import CandlestickChart, { Indicator } from "../../components/CandlestickChart";
 import Select from "../../components/Select";
 import { TIMEFRAME_OPTIONS } from "../../timeframes";
 import { ChartDataProvider, useChartData } from "../../features/datasources/ChartDataProvider";
+import { calculateIndicators } from "../../services/indicatorEngine";
+
+function timeframeToMinutes(tf: string): number {
+  const m = tf.match(/^(\d+)([mhd])$/);
+  if (!m) return 0;
+  const v = Number(m[1]);
+  switch (m[2]) {
+    case "m":
+      return v;
+    case "h":
+      return v * 60;
+    case "d":
+      return v * 1440;
+    default:
+      return 0;
+  }
+}
 
 const ChartContent = () => {
-  const { candleData, range, timeframe, setTimeframe, isLoading, error, handleRangeChange } =
-    useChartData();
+  const {
+    candleData,
+    range,
+    timeframe,
+    setTimeframe,
+    isLoading,
+    error,
+    handleRangeChange,
+    symbol,
+  } = useChartData();
+  const [indicators, setIndicators] = useState<Indicator[]>([]);
+
+  useEffect(() => {
+    if (!symbol || candleData.length === 0) {
+      setIndicators([]);
+      return;
+    }
+    const tfNum = timeframeToMinutes(timeframe);
+    calculateIndicators(symbol, tfNum, [{ name: "iMA", args: [20, 0, 0, 0, 0] }]).then((res) => {
+      const values = res["iMA"] ?? [];
+      const start = values.length - candleData.length;
+      const data = candleData.map((c, i) => ({
+        date: c.date,
+        value: values[start + i] ?? 0,
+      }));
+      setIndicators([{ name: "iMA", color: "#0ea5e9", data }]);
+    });
+  }, [symbol, timeframe, candleData]);
   return (
     <div className="p-6 space-y-4">
       <h2 className="text-2xl font-bold">チャート表示</h2>
@@ -21,6 +65,7 @@ const ChartContent = () => {
       <CandlestickChart
         data={candleData}
         range={range ?? undefined}
+        indicators={indicators}
         onRangeChange={handleRangeChange}
       />
     </div>

--- a/frontend/src/services/stratrackMarketData.ts
+++ b/frontend/src/services/stratrackMarketData.ts
@@ -1,0 +1,66 @@
+import type {
+  Candle,
+  Tick,
+  IMarketData,
+} from "../../../libs/mql-interpreter/src/libs/domain/marketData/types.ts";
+
+export class ApiMarketData implements IMarketData {
+  private candles: Record<string, Record<number, Candle[]>> = {};
+  private symbols = new Set<string>();
+  private selected = new Set<string>();
+
+  async load(symbol: string, timeframe: number): Promise<void> {
+    if (this.candles[symbol]?.[timeframe]) return;
+    const res = await fetch(`/api/market/${symbol}/${timeframe}`);
+    const data: Candle[] = await res.json();
+    if (!this.candles[symbol]) this.candles[symbol] = {};
+    this.candles[symbol][timeframe] = data;
+    this.symbols.add(symbol);
+  }
+
+  async update(symbol: string, timeframe: number): Promise<Candle[]> {
+    const arr = this.candles[symbol]?.[timeframe] ?? [];
+    const since = arr.length ? arr[arr.length - 1].time : 0;
+    const res = await fetch(`/api/market/${symbol}/${timeframe}?since=${since}`);
+    const data: Candle[] = await res.json();
+    if (!this.candles[symbol]) this.candles[symbol] = {};
+    if (!this.candles[symbol][timeframe]) this.candles[symbol][timeframe] = [];
+    this.candles[symbol][timeframe].push(...data);
+    this.symbols.add(symbol);
+    return data;
+  }
+
+  getSymbols(selectedOnly = false): string[] {
+    return Array.from(selectedOnly ? this.selected : this.symbols);
+  }
+
+  select(symbol: string, enable: boolean): boolean {
+    if (enable) this.selected.add(symbol);
+    else this.selected.delete(symbol);
+    return true;
+  }
+
+  getIndex(symbol: string, timeframe: number, time: number): number {
+    const arr = this.candles[symbol]?.[timeframe];
+    if (!arr) return -1;
+    let i = arr.length - 1;
+    while (i >= 0 && arr[i].time > time) i--;
+    return i;
+  }
+
+  getTick(symbol: string, time: number): Tick | undefined {
+    void symbol;
+    void time;
+    return undefined;
+  }
+
+  getCandle(symbol: string, timeframe: number, time: number): Candle | undefined {
+    const index = this.getIndex(symbol, timeframe, time);
+    const arr = this.candles[symbol]?.[timeframe];
+    return index >= 0 && arr ? arr[index] : undefined;
+  }
+
+  getCandles(symbol: string, timeframe: number): Candle[] {
+    return this.candles[symbol]?.[timeframe] ?? [];
+  }
+}

--- a/libs/mql-interpreter/src/libs/domain/marketData/inMemoryMarketData.ts
+++ b/libs/mql-interpreter/src/libs/domain/marketData/inMemoryMarketData.ts
@@ -33,7 +33,7 @@ export class InMemoryMarketData implements IMarketData {
     return true;
   }
 
-  getIndex(symbol: string, timeframe: number, time: number): number {
+  getIndex(symbol: string, _timeframe: number, time: number): number {
     const arr = this.ticks[symbol];
     if (!arr || !arr.length) return -1;
     let pos = this.positions[symbol] ?? 0;


### PR DESCRIPTION
## Summary
- expose datasource symbol and provide indicator calculation hook
- overlay moving average results on candlestick chart

## Testing
- `npm run format`
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b3e0275d688320b05d8d4c2fd6553a