### PR TITLE
feat: compile custom indicators on edit

### DIFF
--- a/frontend/src/codegen/generators/indicatorCodeRenderer.ts
+++ b/frontend/src/codegen/generators/indicatorCodeRenderer.ts
@@ -1,0 +1,35 @@
+import { Indicator } from "../dsl/indicator";
+import { analyzeTemplate, StrategyAnalysisContext } from "../analyzers";
+import { buildIRFromAnalysis } from "../ir/builder";
+import { convertIrToMqlProgram, renderMqlProgram } from "../mql";
+
+export function renderIndicatorMql(indicator: Indicator): string {
+  const analysis = analyzeTemplate(indicator.template, {
+    [indicator.name]: indicator,
+  });
+  const ctx: StrategyAnalysisContext = {
+    strategy: {
+      variables: [],
+      entry: [],
+      exit: [],
+      riskManagement: { type: "fixed", lotSize: 0 },
+    },
+    indicatorDefinitions: [
+      {
+        name: indicator.name,
+        params: indicator.params,
+        indicator,
+        indicatorInstances: [],
+        usedAggregationTypes: analysis.usedAggregationTypes,
+      },
+    ],
+    indicatorInstances: [],
+    usedAggregationTypes: analysis.usedAggregationTypes,
+    variableDependencyOrder: analysis.variableDependencyOrder,
+    variableDependencyGraph: analysis.variableDependencyGraph,
+    errors: analysis.errors,
+  };
+  const ir = buildIRFromAnalysis(ctx);
+  const mqlProgram = convertIrToMqlProgram(ir);
+  return renderMqlProgram(mqlProgram);
+}

--- a/frontend/src/features/datasources/ChartDataProvider.test.tsx
+++ b/frontend/src/features/datasources/ChartDataProvider.test.tsx
@@ -186,7 +186,7 @@ describe("ChartDataProvider", () => {
     });
 
     await act(async () => {
-      indicatorSvc.setIndicatorSource({ foo: "bar" });
+      indicatorSvc.indicatorEngine.set("foo", "bar");
     });
 
     await waitFor(() => {

--- a/frontend/src/features/indicators/IndicatorEditor.tsx
+++ b/frontend/src/features/indicators/IndicatorEditor.tsx
@@ -1,11 +1,19 @@
+import { useEffect } from "react";
 import { Indicator } from "../../codegen/dsl/indicator";
+import { renderIndicatorMql } from "../../codegen/generators/indicatorCodeRenderer";
+import { indicatorEngine } from "../../services/indicatorEngine";
 
 export type IndicatorEditorProps = {
   value?: Partial<Indicator>;
   onChange?: (value: Partial<Indicator>) => void;
 };
 
-function IndicatorEditor() {
+function IndicatorEditor({ value }: IndicatorEditorProps) {
+  useEffect(() => {
+    if (!value?.name || !value.template) return;
+    const src = renderIndicatorMql(value as Indicator);
+    indicatorEngine.set(value.name, src);
+  }, [value]);
   return null;
 }
 

--- a/frontend/src/services/indicatorEngine.ts
+++ b/frontend/src/services/indicatorEngine.ts
@@ -27,8 +27,19 @@ let baseTimeframe = 0;
 let indicatorSource = new InMemoryIndicatorSource();
 const sourceSubscribers = new Set<() => void>();
 
+export const indicatorEngine = {
+  set(name: string, src: string): void {
+    indicatorSource.set(name, src);
+    engine?.set(name, src);
+    for (const cb of sourceSubscribers) cb();
+  },
+};
+
 export function setIndicatorSource(source: Record<string, string>): void {
   indicatorSource = new InMemoryIndicatorSource(source);
+  if (engine) {
+    engine = new InMemoryIndicatorEngine(indicatorSource);
+  }
   for (const cb of sourceSubscribers) cb();
 }
 


### PR DESCRIPTION
## Summary
- compile indicator DSL to MQL4 on edit
- expose indicatorEngine.set to register sources and trigger recalculation
- cover indicator source updates in ChartDataProvider tests

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b41d2ce57c8320bd7850a2d92cf560