### PR TITLE
feat: support multiple indicators with pane selection

### DIFF
--- a/frontend/src/components/IndicatorWizard.tsx
+++ b/frontend/src/components/IndicatorWizard.tsx
@@ -7,7 +7,8 @@ import Button from "./Button";
 
 export type IndicatorWizardProps = {
   indicators: Indicator[];
-  onSubmit?: (indicator: Indicator, params: Record<string, unknown>) => void;
+  onSubmit?: (indicator: Indicator, params: Record<string, unknown>, pane?: number) => void;
+  enablePaneSelection?: boolean;
 };
 
 const SOURCE_OPTIONS = [
@@ -20,10 +21,15 @@ const SOURCE_OPTIONS = [
   { value: "weighted", label: "加重" },
 ];
 
-function IndicatorWizard({ indicators, onSubmit }: IndicatorWizardProps) {
+function IndicatorWizard({
+  indicators,
+  onSubmit,
+  enablePaneSelection = false,
+}: IndicatorWizardProps) {
   const [step, setStep] = useState(0);
   const [selectedName, setSelectedName] = useState("");
   const [params, setParams] = useState<Record<string, unknown>>({});
+  const [pane, setPane] = useState(0);
 
   const selected = indicators.find((i) => i.name === selectedName);
 
@@ -34,6 +40,7 @@ function IndicatorWizard({ indicators, onSubmit }: IndicatorWizardProps) {
       if (p.default !== undefined) defaults[p.name] = p.default;
     }
     setParams(defaults);
+    setPane(0);
   }, [selected]);
 
   const handleParamChange = (name: string, value: unknown) => {
@@ -96,11 +103,12 @@ function IndicatorWizard({ indicators, onSubmit }: IndicatorWizardProps) {
 
   const handleSubmit = () => {
     if (selected && onSubmit) {
-      onSubmit(selected, params);
+      onSubmit(selected, params, pane);
     }
     setStep(0);
     setSelectedName("");
     setParams({});
+    setPane(0);
   };
 
   return (
@@ -121,6 +129,19 @@ function IndicatorWizard({ indicators, onSubmit }: IndicatorWizardProps) {
       {step === 1 && selected && (
         <div className="space-y-2">
           {selected.params.map((p) => renderParamField(p))}
+          {enablePaneSelection && (
+            <Select
+              label="表示先"
+              value={String(pane)}
+              onChange={(v) => setPane(Number(v))}
+              options={[
+                { value: "0", label: "メインチャート" },
+                { value: "1", label: "サブウィンドウ1" },
+                { value: "2", label: "サブウィンドウ2" },
+                { value: "3", label: "サブウィンドウ3" },
+              ]}
+            />
+          )}
           <div className="flex gap-2">
             <Button variant="secondary" onClick={handleBack}>
               戻る

--- a/frontend/src/features/datasources/ChartDataProvider.test.tsx
+++ b/frontend/src/features/datasources/ChartDataProvider.test.tsx
@@ -34,7 +34,7 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 describe("ChartDataProvider", () => {
   beforeEach(() => {
     vi.resetAllMocks();
-    vi.spyOn(indicatorSvc, "calculateIndicators").mockResolvedValue({});
+    vi.spyOn(indicatorSvc, "calculateIndicators").mockResolvedValue([]);
   });
 
   it("loads data on mount", async () => {
@@ -173,6 +173,10 @@ describe("ChartDataProvider", () => {
     ]);
 
     const { result } = renderHook(() => useChartData(), { wrapper });
+
+    await act(async () => {
+      result.current.setIndicatorDefs([{ name: "iMA", args: [] }]);
+    });
 
     await waitFor(() => {
       expect(indicatorSvc.calculateIndicators).toHaveBeenCalledTimes(1);

--- a/frontend/src/features/datasources/ChartDataProvider.tsx
+++ b/frontend/src/features/datasources/ChartDataProvider.tsx
@@ -144,13 +144,13 @@ const ChartDataProvider = ({
     calculateIndicators(symbol, tfNum, indicatorDefs).then((res) => {
       const colors = ["#0ea5e9", "#22c55e", "#9333ea", "#f97316"];
       const mapped: Indicator[] = indicatorDefs.map((def, idx) => {
-        const values = res[def.name] ?? [];
+        const values = res[idx] ?? [];
         const start = values.length - candleData.length;
         const data = candleData.map((c, i) => ({
           date: c.date,
           value: values[start + i] ?? 0,
         }));
-        return { name: def.name, color: colors[idx % colors.length], data };
+        return { name: def.name, color: colors[idx % colors.length], data, pane: def.pane };
       });
       setIndicators(mapped);
     });

--- a/frontend/src/routes/datasources/chart.tsx
+++ b/frontend/src/routes/datasources/chart.tsx
@@ -22,7 +22,7 @@ const ChartContent = () => {
   } = useChartData();
   const indicatorList = useIndicatorList().filter((i) => i.name === "moving_average");
 
-  const handleIndicatorSubmit = (ind: Indicator, params: Record<string, unknown>) => {
+  const handleIndicatorSubmit = (ind: Indicator, params: Record<string, unknown>, pane = 0) => {
     if (ind.name !== "moving_average") return;
     const method = params.method as string;
     const source = params.source as string;
@@ -39,7 +39,10 @@ const ChartContent = () => {
     };
     const maMethod = maMethodMap[method] ?? 0;
     const applied = appliedMap[source] ?? 0;
-    setIndicatorDefs([{ name: "iMA", args: [period, 0, maMethod, applied, 0] }]);
+    setIndicatorDefs((prev) => [
+      ...prev,
+      { name: "iMA", args: [period, 0, maMethod, applied, 0], pane },
+    ]);
   };
   return (
     <div className="p-6 space-y-4">
@@ -52,7 +55,11 @@ const ChartContent = () => {
         onChange={setTimeframe}
         options={TIMEFRAME_OPTIONS.filter((o) => o.value !== "tick")}
       />
-      <IndicatorWizard indicators={indicatorList} onSubmit={handleIndicatorSubmit} />
+      <IndicatorWizard
+        indicators={indicatorList}
+        onSubmit={handleIndicatorSubmit}
+        enablePaneSelection
+      />
       <CandlestickChart
         data={candleData}
         range={range ?? undefined}


### PR DESCRIPTION
## Summary
- allow choosing main or sub chart when adding indicators
- compute multiple indicators concurrently with new pane metadata
- update tests for indicator calculations

## Testing
- `npm run lint`
- `npm run test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b4abcc12fc83209e643276780b1823