### PR TITLE
Fix indicator mapping and add chart story assertions

### DIFF
--- a/frontend/src/components/CandlestickChart.stories.tsx
+++ b/frontend/src/components/CandlestickChart.stories.tsx
@@ -41,6 +41,8 @@ export const Default: Story = {
   },
   play: async ({ canvasElement, args }) => {
     const svg = canvasElement.querySelector("svg") as SVGSVGElement;
+    const paths = svg.querySelectorAll("path");
+    await expect(paths.length).toBeGreaterThan(0);
     fireEvent.wheel(svg, { deltaY: 100 });
     await expect(args.onRangeChange).toHaveBeenCalled();
   },

--- a/frontend/src/features/datasources/ChartDataProvider.tsx
+++ b/frontend/src/features/datasources/ChartDataProvider.tsx
@@ -145,10 +145,13 @@ const ChartDataProvider = ({
       const colors = ["#0ea5e9", "#22c55e", "#9333ea", "#f97316"];
       const mapped: Indicator[] = indicatorDefs.map((def, idx) => {
         const values = res[idx] ?? [];
-        const start = values.length - candleData.length;
+        const slice = values.slice(-candleData.length);
+        const padded = Array.from({ length: candleData.length - slice.length }, () => 0).concat(
+          slice
+        );
         const data = candleData.map((c, i) => ({
           date: c.date,
-          value: values[start + i] ?? 0,
+          value: padded[i] ?? 0,
         }));
         return { name: def.name, color: colors[idx % colors.length], data, pane: def.pane };
       });


### PR DESCRIPTION
## Summary
- fix indicator data alignment in `ChartDataProvider`
- assert indicator rendering in `CandlestickChart` story

## Testing
- `npm run lint`
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c4ef5f2484832097e5e3f4284c8330